### PR TITLE
Add default empty content to uploaded files

### DIFF
--- a/src/githubService.ts
+++ b/src/githubService.ts
@@ -18,16 +18,16 @@ export class GithubService {
         "public": false,
         "files": {
             "settings.json": {
-                "content": ""
+                "content": "// Empty"
             },
             "launch.json": {
-                "content": ""
+                "content": "// Empty"
             },
             "keybindings.json": {
-                "content": ""
+                "content": "// Empty"
             },
             "extensions.json": {
-                "content": ""
+                "content": "// Empty"
             }
 
         }


### PR DESCRIPTION
Hi there. I had an API failure to upload when trying to use the extension in a clean VS Code install. I dug into it and fixed the error, this is my commit message:

Github API fails when one of the default files is sent without any content (ie an empty string). This fixes a bug where a user will get a failure message from the Github API if one of these four default files has not been created by VS Code beforehand.

A disadvantage to this fix is that VS Code provides some good default templates when it creates a file, giving some instruction to the user. Having an existing non-empty file already downloaded will prevent this nice behavior. I think a better fix would be to have GIST_JSON_EMPTY actually be empty of files - I leave that to the repository owner to decide.