### PR TITLE
fix mac-specific keybinding sync

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -18,7 +18,7 @@ export class Environment {
     public FILE_SETTING_NAME: string = "settings.json";
     public FILE_LAUNCH_NAME: string = "launch.json";
     public FILE_KEYBINDING_NAME: string = "keybindings.json";
-    public FILE_KEYBINDING_MAC: string = "keybindings_MAC.json";
+    public FILE_KEYBINDING_MAC: string = "keybindingsMac.json";
     public FILE_KEYBINDING_DEFAULT: string = "keybindings.json";
     public FILE_EXTENSION_NAME : string = "extensions.json";
     public FILE_LOCALE_NAME : string = "locale.json";
@@ -47,9 +47,10 @@ export class Environment {
                 var os = require("os")
                 this.PATH = os.homedir() + '/.config';
                 this.OsType = OsType.Linux;
-            } else
+            } else {
                 this.PATH = '/var/local';
                 this.OsType = OsType.Linux;
+            }
         }
 
         var codePath = this.isInsiders ? '/Code - Insiders' : '/Code';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,24 +279,26 @@ export function activate(context: vscode.ExtensionContext) {
                                 });
                             break;
                         }
-                        case en.FILE_KEYBINDING_DEFAULT || en.FILE_KEYBINDING_MAC: {
-                            
+                        case en.FILE_KEYBINDING_DEFAULT:
+                        case en.FILE_KEYBINDING_MAC: {
+
                             var sourceKeyBinding : string = "";
                             var os : string = null;
                             if (en.OsType == OsType.Mac) {
                                 sourceKeyBinding = en.FILE_KEYBINDING_MAC;
                                 os = "Mac";
                             }
-                            else{
+                            else {
                                 sourceKeyBinding = en.FILE_KEYBINDING_DEFAULT;
                             }
 
                             await fileManager.FileManager.WriteFile(en.FILE_KEYBINDING, res.files[sourceKeyBinding].content).then(
                                 function (added: boolean) {
                                     if (os) {
-                                    vscode.window.showInformationMessage("Keybinding Settings for Mac downloaded Successfully");    
+                                        vscode.window.showInformationMessage("Keybinding Settings for Mac downloaded Successfully");
+                                    } else {
+                                        vscode.window.showInformationMessage("Keybinding Settings downloaded Successfully");
                                     }
-                                    vscode.window.showInformationMessage("Keybinding Settings downloaded Successfully");
                                 }, function (error: any) {
                                     vscode.window.showErrorMessage(common.ERROR_MESSAGE);
                                     return;

--- a/src/githubService.ts
+++ b/src/githubService.ts
@@ -32,10 +32,7 @@ export class GithubService {
             "locale.json": {
                 "content": "// Empty"
             },
-            "keybindingMac.json":{
-                "content": "// Empty"
-            },
-            "keybindingDefault.json":{
+            "keybindingsMac.json": {
                 "content": "// Empty"
             }
         }
@@ -99,8 +96,8 @@ export class GithubService {
                                 exists = true;
                             }
                         });
-                        
-                        if (!exists) {
+
+                        if (!exists && !filename.startsWith("keybindings") {
                              res.files[fileName]  = null;
                         }
                         


### PR DESCRIPTION
The keybindings file was always being set to keybindings.json because
of missing braces. In addition, there were some inconsistencies
between files on what the name of the Mac keybinding filename was.
keybindingDefault is removed from the creation snippet as it should
just be using keybindings.json. Lastly, to prevent settings overrides,
we no longer clear files from the gist when the filename begins with
"keybindings".