### PR TITLE
Remove unnecessary info message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -451,10 +451,7 @@ export async function activate(context: vscode.ExtensionContext) {
                                 }
 
                                 var missingList = PluginService.GetMissingExtensions(remoteList);
-                                if (missingList.length == 0) {
-                                    vscode.window.showInformationMessage("No extension need to be installed");
-                                }
-                                else {
+                                if (missingList.length > 0) {
 
                                     vscode.window.setStatusBarMessage("Sync : Installing Extensions in background.");
                                     missingList.forEach(async (element) => {


### PR DESCRIPTION
I noticed I started getting the message "No extension need to be installed" every time VScode started. This message does not give any value, and is kind of annoying, so I removed it.