### PR TITLE
update to force-download

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -342,16 +342,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 if (res) {
                     var keys = Object.keys(res.files);
-                    if (keys.indexOf(en.FILE_CLOUDSETTINGS_NAME) > -1) {
-                        var cloudSett: CloudSetting = JSON.parse(res.files[en.FILE_CLOUDSETTINGS_NAME].content);
-                        var stat: boolean = (syncSetting.lastUpload == cloudSett.lastUpload) || (syncSetting.lastDownload == cloudSett.lastUpload);
-                        if (stat) {
-                            vscode.window.setStatusBarMessage("");
-                            vscode.window.setStatusBarMessage("Sync : You already have latest version of saved settings.", 5000);
-                            return;
-                        }
-                        syncSetting.lastDownload = cloudSett.lastUpload;
-                    }
 
                     keys.forEach(fileName => {
                         if (fileName.indexOf(".") > -1) {
@@ -429,7 +419,7 @@ export async function activate(context: vscode.ExtensionContext) {
                                 writeFile = false;
 
                                 var extensionlist = PluginService.CreateExtensionList();
-                                
+
                                 extensionlist.sort(function (a, b) {
                                     return a.name.localeCompare(b.name);
                                 });


### PR DESCRIPTION
Sometimes I inadvertently break my local settings, for now, I have no way to reset to the cloud version, even through the "Download Settings" command. So I decide to remove the **date comparison** logic to be able to overwrite my local settings.

Meanwhile, I think we may should **provide another function called "Sync Settings"** and move this "date comparison" into it. Then this function (command) will finish the automated update and download (not only compare the time-stamp but also compare the content of each settings file).

Thus we get:

1. Download Settings: always download settings from cloud;
2. Upload Settings: always upload settings from local;
3. Sync Settings: automatically upload and download settings.

And I love this extension! :100: 