### PR TITLE
Cross platform sync summary fix

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -4,6 +4,7 @@ import {Environment} from './environmentPath';
 import {File, FileManager} from './fileManager';
 import {LocalSetting} from './setting';
 import {PluginService, ExtensionInformation} from './pluginService';
+import * as fs from 'fs';
 
 var isOnline = require('is-online');
 
@@ -217,7 +218,8 @@ export class Commons {
 
         console.log("FILE URI For Summary Page : " + tempURI);
 
-        var setting: vscode.Uri = vscode.Uri.parse("untitled:" + tempURI);
+        var setting: vscode.Uri = vscode.Uri.file(tempURI);
+        fs.openSync(setting.fsPath, 'w');
 
         vscode.workspace.openTextDocument(setting).then((a: vscode.TextDocument) => {
 
@@ -272,7 +274,8 @@ export class Commons {
                         }
                     }
                 });
-            });
+                e.document.save();
+            });            
         }, (error: any) => {
             console.error(error);
             return;

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -215,10 +215,6 @@ export class Commons {
         var addedExtension: string = "\r\nEXTENSIONS ADDED : \r\n";
         var tempURI: string = this.en.APP_SUMMARY;
 
-        while (tempURI.indexOf("/") > -1) {
-            tempURI = tempURI.replace("/", "\\");
-        }
-
         console.log("FILE URI For Summary Page : " + tempURI);
 
         var setting: vscode.Uri = vscode.Uri.parse("untitled:" + tempURI);

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -36,7 +36,7 @@ export class Environment {
     
     public FOLDER_SNIPPETS: string = null;
     public APP_SETTINGS : string = null;
-    public APP_SUMMARY_NAME : string = "summary.txt";
+    public APP_SUMMARY_NAME : string = "syncSummary.txt";
     public APP_SUMMARY : string = null;
 
     constructor(context: vscode.ExtensionContext) {


### PR DESCRIPTION
Fixes #90.

Switches to an actual file that is created on demand, and recreated every time a sync (that results in changes) is performed.

Using an actual file has the beneficial side effect of being able to save it and thereby mark it as clean, so that no prompt for saving is shown on exiting VSCode.