### PR TITLE
Fallback to system defined proxy. Issue #126

### DIFF
--- a/src/githubService.ts
+++ b/src/githubService.ts
@@ -4,10 +4,10 @@ import * as envir from './environmentPath';
 import * as fileManager from './fileManager';
 import * as vscode from 'vscode';
 
+var proxyURL: string = vscode.workspace.getConfiguration("http")["proxy"] || process.env["http_proxy"];
 var GitHubApi = require("github");
-
 var github = new GitHubApi({
-    proxy: vscode.workspace.getConfiguration("http")["proxy"],
+    proxy: proxyURL,
     version: "3.0.0",
 });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 var adm_zip = require('adm-zip');
 var temp = require('temp').track();
 var HttpsProxyAgent = require("https-proxy-agent");
-var proxy = vscode.workspace.getConfiguration("http")["proxy"];
+var proxy = vscode.workspace.getConfiguration("http")["proxy"] || process.env["http_proxy"];
 var agent = null;
 if(proxy!=""){
     agent = new HttpsProxyAgent(proxy);


### PR DESCRIPTION
Allows extension to use the HTTP_PROXY environmental variable when the http.proxy setting is not defined in VS Code's User settings.  Closes Issue #126 