### PR TITLE
Add check for port in http options

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -32,11 +32,13 @@ export class Util {
                 Object.assign(newHeader, headers);
                 var options: https.RequestOptions = {
                     host: item.hostname,
-                    port: +item.port,
                     path: item.path,
                     method: 'POST',
                     headers: newHeader,
 
+                }
+                if (item.port) {
+                    options.port = +item.port
                 }
                 if (agent != null) {
                     options.agent = agent;


### PR DESCRIPTION
Check for port being not-null in the parsed URL prior to making a request.
Passing in a null port causes node to connect with SSL on the wrong port.

Fixes #263 