### PR TITLE
Update Project Manager default ignore files.

### DIFF
--- a/src/setting.ts
+++ b/src/setting.ts
@@ -59,6 +59,8 @@ export class CustomSettings {
         this.ignoreUploadFiles.push("projects_cache_vscode.json")
         this.ignoreUploadFiles.push("projects_cache_git.json")
         this.ignoreUploadFiles.push("projects_cache_svn.json")
+        this.ignoreUploadFiles.push("gpm_projects.json")
+        this.ignoreUploadFiles.push("gpm-recentItems.json")
         this.gistDescription = "Visual Studio Code Settings Sync Gist";
         this.version = Environment.CURRENT_VERSION;
         this.token = "";

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -56,7 +56,9 @@ export class CustomSettings {
         this.ignoreUploadSettings = new Array<string>();
         this.ignoreUploadFolders.push("workspaceStorage");
         this.ignoreUploadFiles.push("projects.json");
+        this.ignoreUploadFiles.push("projects_cache_vscode.json")
         this.ignoreUploadFiles.push("projects_cache_git.json")
+        this.ignoreUploadFiles.push("projects_cache_svn.json")
         this.gistDescription = "Visual Studio Code Settings Sync Gist";
         this.version = Environment.CURRENT_VERSION;
         this.token = "";


### PR DESCRIPTION
In additition to the git project cache, Project Manager can also create cache files with `vscode` and `svn` names. This change adds these files to the default ignore list.

In addition, this change adds the Git Project Manager files to the default ignore
    
The Git Project Manager uses `gpm_projects.json` and `gpm-recentItems.json` files to store the cached list of projects.

These should be excluded by default for anyone using this extension.

The Git Project Manager extension is here: https://marketplace.visualstudio.com/items?itemName=felipecaputo.git-project-manager