### PR TITLE
Remove unused var. Closes #424

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -583,7 +583,7 @@ export async function activate(context: vscode.ExtensionContext) {
         var selectedItem: Number = 0;
         var settingChanged: boolean = false;
 
-        var teims = vscode.window.showQuickPick(items).then(async (resolve: string) => {
+        vscode.window.showQuickPick(items).then(async (resolve: string) => {
 
             switch (resolve) {
                 case items[0]: {


### PR DESCRIPTION
I do not see the point of the var teims. Instead of fixing the typo i removed it and just let the promise call since i didn`t find the var being used or passed anywhere. Are we actually using it? If so i can change this PR to just fix the typo