### PR TITLE
Added support for "Code - OSS"

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -1,6 +1,7 @@
 "use strict";
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { statSync } from 'fs';
 import { OsType } from './enums';
 
 export class Environment {
@@ -82,8 +83,14 @@ export class Environment {
             });
         }
 
-        var codePath = this.isInsiders ? '/Code - Insiders' : '/Code';
-        this.PATH = this.PATH + codePath;
+        const possibleCodePaths = [this.isInsiders ? '/Code - Insiders' : '/Code', '/Code - OSS'];
+        for (const _path of possibleCodePaths) {
+            try {
+                fs.statSync(this.PATH + _path);
+                this.PATH = this.PATH + _path;
+                break;
+            } catch(e) {}
+        }
         this.USER_FOLDER = this.PATH.concat("/User/");
 
         this.FILE_EXTENSION = this.PATH.concat("/User/", this.FILE_EXTENSION_NAME);


### PR DESCRIPTION
Looks like `environmentPath.ts` is looking for a specific path "/Code" ( or "/Code - Insiders"). For me, this path doesn't exist since I'm using the open-source version of VS Code, thus the path which should be looked for is "/Code - OSS". I don't know if any other changes in other files should be made, but this seems to work.