### PR TITLE
Ignore extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Previously known as Visual Studio Code Settings Sync**
 
-[![Version](https://vsmarketplacebadge.apphb.com/version/Shan.code-settings-sync.svg)](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) [![Travis](https://img.shields.io/travis/rust-lang/rust.svg)](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) 
+[![Version](https://vsmarketplacebadge.apphb.com/version/Shan.code-settings-sync.svg)](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) [![Travis](https://img.shields.io/travis/rust-lang/rust.svg)](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync)
 [![Greenkeeper badge](https://badges.greenkeeper.io/shanalikhan/code-settings-sync.svg)](https://greenkeeper.io/)
 
 
@@ -82,7 +82,7 @@ Enter the GitHub token in the window and click enter.
 ![github account access token](https://shanalikhan.github.io/img/upload1.png)
 
 **Upload your settings automatically and the extension gives you Gist ID in the system message.**
-Gist ID is needed to access the data you have uploaded with your token. Copy this Gist ID in order to download the settings to other machines. 
+Gist ID is needed to access the data you have uploaded with your token. Copy this Gist ID in order to download the settings to other machines.
 
 ![uploaded automatically](https://shanalikhan.github.io/img/upload2.png)
 
@@ -215,6 +215,9 @@ The JSON will be created as:
     ],
     "ignoreUploadFolders": [
         "workspaceStorage"
+    ],
+    "ignoreExtensions": [
+        "ignored_extension_name"
     ],
     "replaceCodeSettings": {
          "http.proxy": "http://my.proxy.address:8080"

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -537,7 +537,7 @@ export default class Commons {
 
     }
 
-    public ShowSummmaryOutput(upload: boolean, files: Array<File>, removedExtensions: Array<ExtensionInformation>, addedExtensions: Array<ExtensionInformation>, syncSettings: LocalConfig) {
+    public ShowSummmaryOutput(upload: boolean, files: Array<File>, removedExtensions: Array<ExtensionInformation>, addedExtensions: Array<ExtensionInformation>, ignoredExtensions: Array<ExtensionInformation>, syncSettings: LocalConfig) {
         if (Commons.outputChannel === null) {
             Commons.outputChannel = vscode.window.createOutputChannel("Code Settings Sync");
         }
@@ -572,22 +572,31 @@ export default class Commons {
             });
 
         outputChannel.appendLine(``);
-        outputChannel.appendLine(`  Extensions Removed:`);
+        outputChannel.appendLine(`Extensions Ignored:`);
 
-        if (!syncSettings.extConfig.removeExtensions) {
-            outputChannel.appendLine(' Feature Disabled.');
+        if (!ignoredExtensions || ignoredExtensions.length === 0) {
+            outputChannel.appendLine(`  No extensions ignored.`);
         }
         else {
-            if (removedExtensions) {
-                if (removedExtensions.length === 0) {
-                    outputChannel.appendLine("  No extensions removed.");
-                }
-                else {
+            ignoredExtensions.forEach(extn => {
+                outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+            });
+        }
 
-                    removedExtensions.forEach(extn => {
-                        outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
-                    });
-                }
+        outputChannel.appendLine(``);
+        outputChannel.appendLine(`Extensions Removed:`);
+
+        if (!syncSettings.extConfig.removeExtensions) {
+            outputChannel.appendLine(`  Feature Disabled.`);
+        }
+        else {
+            if (!removedExtensions || removedExtensions.length === 0) {
+                outputChannel.appendLine(`  No extensions removed.`);
+            }
+            else {
+                removedExtensions.forEach(extn => {
+                    outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+                });
             }
         }
 
@@ -596,7 +605,7 @@ export default class Commons {
             outputChannel.appendLine(`Extensions Added:`)
 
             if (addedExtensions.length === 0) {
-                outputChannel.appendLine("  No extensions installed.");
+                outputChannel.appendLine(`  No extensions installed.`);
             }
 
             addedExtensions.forEach(extn => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
         let localConfig: LocalConfig = new LocalConfig();
         let allSettingFiles = new Array<File>();
         let uploadedExtensions = new Array<ExtensionInformation>();
+        let ignoredExtensions = new Array<ExtensionInformation>();
         let dateNow: Date = new Date();
         common.CloseWatch();
         let ignoreSettings = new Object();
@@ -86,7 +87,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             if (customSettings.downloadPublicGist) {
                 if (customSettings.token == null || customSettings.token == "") {
-                    vscode.window.showInformationMessage("Sync : Set GitHub Token or disable 'downloadPublicGist' from local Sync settings file.");;
+                    vscode.window.showInformationMessage("Sync : Set GitHub Token or disable 'downloadPublicGist' from local Sync settings file.");
                     return;
                 }
             }
@@ -102,7 +103,11 @@ export async function activate(context: vscode.ExtensionContext) {
                 uploadedExtensions = PluginService.CreateExtensionList();
                 if (customSettings.ignoreExtensions && customSettings.ignoreExtensions.length > 0) {
                     uploadedExtensions = uploadedExtensions.filter(extension => {
-                        return !customSettings.ignoreExtensions.includes(extension.name)
+                        if (customSettings.ignoreExtensions.includes(extension.name)) {
+                            ignoredExtensions.push(extension);
+                            return false;
+                        }
+                        return true;
                     })
                 }
                 uploadedExtensions.sort(function (a, b) {
@@ -253,7 +258,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         }
 
                         if (!syncSetting.quietSync) {
-                            common.ShowSummmaryOutput(true, allSettingFiles, null, uploadedExtensions, localConfig);
+                            common.ShowSummmaryOutput(true, allSettingFiles, null, uploadedExtensions, ignoredExtensions, localConfig);
                             vscode.window.setStatusBarMessage("").dispose();
                         }
                         else {
@@ -367,9 +372,18 @@ export async function activate(context: vscode.ExtensionContext) {
                             if (file.gistName == en.FILE_EXTENSION_NAME) {
                                 if (syncSetting.syncExtensions) {
                                     var extDelStatus: Array<KeyValue<string, boolean>> = new Array<KeyValue<string, boolean>>();
+
+                                    if (customSettings.ignoreExtensions && customSettings.ignoreExtensions.length) {
+                                        const extList = ExtensionInformation.fromJSONList(content)
+                                        const newExtList = extList.filter(extension =>
+                                            !customSettings.ignoreExtensions.includes(extension.name)
+                                        )
+                                        content = JSON.stringify(newExtList)
+                                    }
+
                                     if (syncSetting.removeExtensions) {
                                         try {
-                                            deletedExtensions = await PluginService.DeleteExtensions(file.content, en.ExtensionFolder);
+                                            deletedExtensions = await PluginService.DeleteExtensions(content, en.ExtensionFolder);
                                         }
                                         catch (uncompletedExtensions) {
                                             vscode.window.showErrorMessage("Sync : Unable to remove some extensions.");
@@ -378,7 +392,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
                                     }
                                     try {
-                                        addedExtensions = await PluginService.InstallExtensions(file.content, en.ExtensionFolder, function (message: string, dispose: boolean) {
+                                        addedExtensions = await PluginService.InstallExtensions(content, en.ExtensionFolder, function (message: string, dispose: boolean) {
                                             //TODO:
                                             if (dispose) {
                                                 vscode.window.setStatusBarMessage(message, 2000);
@@ -443,7 +457,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         await common.SaveSettings(syncSetting).then(async function (added: boolean) {
                             if (added) {
                                 if (!syncSetting.quietSync) {
-                                    common.ShowSummmaryOutput(false, updatedFiles, deletedExtensions, addedExtensions, localSettings);
+                                    common.ShowSummmaryOutput(false, updatedFiles, deletedExtensions, addedExtensions, null, localSettings);
                                     vscode.window.setStatusBarMessage("").dispose();
                                 }
                                 else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,11 @@ export async function activate(context: vscode.ExtensionContext) {
             // var deletedList = PluginService.GetDeletedExtensions(uploadedExtensions);
             if (syncSetting.syncExtensions) {
                 uploadedExtensions = PluginService.CreateExtensionList();
-
+                if (customSettings.ignoreExtensions && customSettings.ignoreExtensions.length > 0) {
+                    uploadedExtensions = uploadedExtensions.filter(extension => {
+                        return !customSettings.ignoreExtensions.includes(extension.name)
+                    })
+                }
                 uploadedExtensions.sort(function (a, b) {
                     return a.name.localeCompare(b.name);
                 });

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -16,7 +16,7 @@ export class ExtensionConfig {
     public lastUpload: Date = null;
     public lastDownload: Date = null;
     public forceDownload: boolean = false;
-    
+
 }
 
 export class LocalConfig {
@@ -41,15 +41,16 @@ export class CloudSetting {
 }
 
 export class KeyValue<T,S>{
-    
+
     constructor(public Key : T , public Value : S){
-        
+
     }
 }
 
 export class CustomSettings {
     public ignoreUploadFiles: Array<string> = null;
     public ignoreUploadFolders: Array<string> = null;
+    public ignoreExtensions: Array<string> = null;
     public ignoreUploadSettings: Array<string> = null;
     public replaceCodeSettings: Object = null;
     public gistDescription: string = null;
@@ -61,6 +62,7 @@ export class CustomSettings {
 
         this.ignoreUploadFiles = new Array<string>();
         this.ignoreUploadFolders = new Array<string>();
+        this.ignoreExtensions = new Array<string>();
         this.replaceCodeSettings = new Object();
         this.ignoreUploadSettings = new Array<string>();
         this.supportedFileExtensions = new Array<string>();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,11 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es7"
         ],
         "sourceMap": true,
         "rootDir": "."
-    }, 
+    },
     "exclude": [
         "node_modules",
         ".vscode-test"


### PR DESCRIPTION
Added functionality for users to define extensions to be ignored through syncLocalSettings.json - any extension names will be ignored when syncing up and down.