### PR TITLE
Fix uri string typo on 'How to configure' executeCommand action.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -518,7 +518,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     var howSettings = vscode.commands.registerCommand('extension.HowSettings', async () => {
-        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('"http://shanalikhan.github.io/2015/12/15/Visual-Studio-Code-Sync-Settings.html'));
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('http://shanalikhan.github.io/2015/12/15/Visual-Studio-Code-Sync-Settings.html'));
     });
 
     var otherOptions = vscode.commands.registerCommand('extension.otherOptions', async () => {


### PR DESCRIPTION
Hi @shanalikhan , I just installed your plugin in VSCode 1.23.0 with Ubuntu 16.04 64-bit OS. 

**Step to reproduce:**
1. Install Code Settings Sync plugin.
2. Open Command palette using Ctrl + Shift + P.
3. Click `Sync: How to Configure`

**Expected behaviour:**
It will open browser to the 'How to configure' link.

**Actual Behaviour:**
When I click the **How to Configure** from the command palette, the VSCode return  `[UriError]: Scheme contains illegal characters.`.


After that, I forked your source code and find what's the problem that cause the error. Finally, I found it and fix it. Hope the fix is right and not conflict with others. Thank you for the plugins. :+1: 