### PR TITLE
fix: isXDG check always failing

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -54,7 +54,7 @@ export class Environment {
         this.context = context;
         this.isInsiders = /insiders/.test(context.asAbsolutePath(""));
         this.isOss = /\boss\b/.test(context.asAbsolutePath(""));
-        const isXdg = !this.isInsiders && !!this.isOss && process.platform === 'linux' && !!process.env.XDG_DATA_HOME
+        const isXdg = process.platform === 'linux' && !!process.env.XDG_DATA_HOME;
         this.homeDir = isXdg
             ? process.env.XDG_DATA_HOME
             : process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];


### PR DESCRIPTION
Simplify the isXDG check to only look at what is necessary.
Previously the checks against the type of Code build would trigger it to always be `false`. 
This however breaks operation within environments with XDG configs.
Removing these checks allows the check to function as needed for custom directories.

This fixes using the extension in environments such as [flatpaks](https://flathub.org/apps/details/com.visualstudio.code). Without this change, the extension fails to find the right extension directory.

*Ideally* the extension should be modified so it respects any user-provided [--extensions-dir argument](https://code.visualstudio.com/docs/editor/command-line#_advanced-cli-options). However I couldn't find a quick way of doing that (since the extension's process does not have access to the arguments from program launch.) So I simply fixed the check as a quick solutions for things that are using the same folder structure, just moving the `$HOME` location.