### PR TITLE
Add support for VSCodium

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -102,13 +102,15 @@ export class Environment {
       });
     }
 
-    const possibleCodePaths = [
-      this.isInsiders
-        ? "/Code - Insiders"
-        : this.isOss
-          ? "/Code - OSS"
-          : "/Code"
-    ];
+    const possibleCodePaths = [];
+    if (this.isInsiders) {
+      possibleCodePaths.push("/Code - Insiders");
+    } else if (this.isOss) {
+      possibleCodePaths.push("/Code - OSS");
+      possibleCodePaths.push("/VSCodium");
+    } else {
+      possibleCodePaths.push("/Code");
+    }
     for (const possibleCodePath of possibleCodePaths) {
       try {
         fs.statSync(this.PATH + possibleCodePath);


### PR DESCRIPTION
Fixes #650 and downstream issue https://github.com/VSCodium/vscodium/issues/17

VSCodium still uses the `.vscode-oss` path, but because the name of the application is `VSCodium` and not `Code - OSS`, this extension was unable to find the settings path. This PR adds the VSCodium path as an option if `isOss` is true.