### PR TITLE
Environment - treat non-OSS instalations on Linux as XDG

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -59,7 +59,6 @@ export class Environment {
     this.isOss = /\boss\b/.test(this.context.asAbsolutePath(""));
     const isXdg =
       !this.isInsiders &&
-      !!this.isOss &&
       process.platform === "linux" &&
       !!process.env.XDG_DATA_HOME;
     this.homeDir = isXdg


### PR DESCRIPTION
Non-OSS installations on Linux should use XDG paths.
As a side effect this also fixes #621 (Flatpak support).