### PR TITLE
Update non-functional link in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ You can contribute me financially by two ways:
 ### Contributors
 
 Thank you to all the people who have already contributed to Settings Sync!
-<a href="graphs/contributors"><img src="https://opencollective.com/code-settings-sync/contributors.svg?width=890" /></a>
+<a href="https://github.com/shanalikhan/code-settings-sync/graphs/contributors"><img src="https://opencollective.com/code-settings-sync/contributors.svg?width=890" /></a>
 
 ### Backers
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ You can contribute in different ways. Read the details [here](https://github.com
 ### Contributors
 
 Thank you to all the people who have already contributed to Settings Sync!
-<a href="graphs/contributors"><img src="https://opencollective.com/code-settings-sync/contributors.svg?width=890" /></a>
+<a href="https://github.com/shanalikhan/code-settings-sync/graphs/contributors"><img src="https://opencollective.com/code-settings-sync/contributors.svg?width=890" /></a>
 
 ### Backers
 


### PR DESCRIPTION
## Issue description:

The hrefs inside README.md and CONTRIBUTING.md were set to graphs/contributors which directs to a non-existent page (https://github.com/shanalikhan/code-settings-sync/blob/master/graphs/contributors)

## Solution:

I have changed both to point to https://github.com/shanalikhan/code-settings-sync/graphs/contributors instead.