### PR TITLE
Fix for temp.mkdir returning double paths #642

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -142,13 +142,9 @@ export class Util {
   }
 
   public static async Extract(filePath: string) {
-    const dirName = temp.path();
     const zip = new adm_zip(filePath);
-
-    await promisify(temp.mkdir)(dirName);
-
+    const dirName = await promisify(temp.mkdir)(undefined);
     zip.extractAllTo(dirName, /*overwrite*/ true);
-
     return dirName;
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:

Downloaded extensions fails to extract to the temporary folder.

#### Changes proposed in this pull request:

The first argument of temp.mkdir method does not take a path. It takes an affix for the created folder name. If you leave the affix as undefined (or anything falsy), it will defaults to 'd-' and create and return (a promise of) the full path of a folder that gets the name 'd-' + todays date + process Id + a random number.

**Fixes**: #642 
