### PR TITLE
Add webpack bundling for faster startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+			"outFiles": ["${workspaceRoot}/out/**/*.js"],
 			"preLaunchTask": "npm"
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "tslint-check": "tslint -c ./tslint.json ./src/**/*.ts ./src/*.ts",
     "format": "prettier --write './src/**/*.ts'",
-    "test": "npm run vscode:prepublish && node ./node_modules/bin/mocha --recursive"
+    "test": "npm run tslint-check && tsc -p ./ && node ./node_modules/bin/mocha --recursive"
   },
   "devDependencies": {
     "@types/chai": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "activationEvents": [
     "*"
   ],
-  "main": "./out/src/extension",
+  "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
@@ -143,26 +143,30 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run tslint-check && npm run compile",
-    "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "npm run tslint-check && webpack --mode production",
+    "compile": "webpack",
+    "watch": "webpack --mode development --watch",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "tslint-check": "tslint -c ./tslint.json ./src/**/*.ts ./src/*.ts",
     "format": "prettier --write './src/**/*.ts'",
     "test": "npm run vscode:prepublish && node ./node_modules/bin/mocha --recursive"
   },
   "devDependencies": {
-    "@types/fs-extra": "^5.0.4",
-    "@types/node": "^10.12.10",
     "@types/chai": "4.1.7",
+    "@types/fs-extra": "^5.0.4",
     "@types/mocha": "^5.2.5",
+    "@types/node": "^10.12.10",
     "chai": "^4.2.0",
+    "clean-webpack-plugin": "^1.0.0",
     "mocha": "^5.2.0",
     "prettier": "^1.15.2",
+    "ts-loader": "^5.3.0",
     "tslint": "^5.11.0",
     "tslint-plugin-prettier": "^2.0.0",
     "typescript": "^3.1.2",
-    "vscode": "^1.1.21"
+    "vscode": "^1.1.21",
+    "webpack": "^4.26.1",
+    "webpack-cli": "^3.1.2"
   },
   "dependencies": {
     "@octokit/rest": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "tslint-check": "tslint -c ./tslint.json ./src/**/*.ts ./src/*.ts",
     "format": "prettier --write './src/**/*.ts'",
-    "test": "npm run tslint-check && tsc -p ./ && node ./node_modules/bin/mocha --recursive"
+    "test": "npm run tslint-check && tsc -p ./ && mocha --recursive \"./out/test/**/*.js\""
   },
   "devDependencies": {
     "@types/chai": "4.1.7",

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -647,9 +647,11 @@ export default class Commons {
     outputChannel.appendLine(`--------------------`);
 
     outputChannel.appendLine(`Files ${upload ? "Upload" : "Download"}ed:`);
-    files.filter(item => item.fileName.indexOf(".") > 0).forEach(item => {
-      outputChannel.appendLine(`  ${item.fileName} > ${item.gistName}`);
-    });
+    files
+      .filter(item => item.fileName.indexOf(".") > 0)
+      .forEach(item => {
+        outputChannel.appendLine(`  ${item.fileName} > ${item.gistName}`);
+      });
 
     outputChannel.appendLine(``);
     outputChannel.appendLine(`Extensions Ignored:`);

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -80,7 +80,9 @@ export class Localize {
     // then merger the Language pack
     // just in case the resolveLanguage bundle missing the translation and fallback with default language
     if (resolvedLanguage !== defaultResvoleLanguage) {
-      defaultLanguageBundle = require(path.join(file + defaultResvoleLanguage));
+      defaultLanguageBundle = JSON.parse(
+        fs.readFileSync(path.join(file + defaultResvoleLanguage), "utf-8")
+      );
     }
 
     const languageFilePath = path.join(file + resolvedLanguage);
@@ -88,7 +90,7 @@ export class Localize {
     const isExistResolvedLanguage = await fs.pathExists(languageFilePath);
 
     const ResolvedLanguageBundle = isExistResolvedLanguage
-      ? require(languageFilePath)
+      ? JSON.parse(fs.readFileSync(languageFilePath, "utf-8"))
       : {};
 
     // merger with default language bundle

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,44 @@
+//@ts-check
+/** @typedef {import('webpack').Configuration} WebpackOptions **/
+
+"use strict";
+
+const path = require("path");
+const CleanWebpackPlugin = require("clean-webpack-plugin");
+
+/** @type WebpackOptions */
+const config = {
+  mode: "none",
+  target: "node",
+  entry: "./src/extension.ts",
+  output: {
+    filename: "extension.js",
+    path: path.resolve(__dirname, "out"),
+    libraryTarget: "commonjs2",
+    devtoolModuleFilenameTemplate: "file:///[absolute-resource-path]"
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+    alias: {
+      deepmerge$: path.resolve(__dirname, "node_modules/deepmerge/dist/umd.js")
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        loader: "ts-loader"
+      }
+    ]
+  },
+  externals: {
+    vscode: "commonjs vscode",
+    fsevents: "commonjs fsevents",
+    "original-fs": "commonjs original-fs"
+  },
+  devtool: "source-map",
+  plugins: [new CleanWebpackPlugin(["out"])]
+};
+
+module.exports = config;


### PR DESCRIPTION
#### Short description of what this resolves:
This PR improves extension startup time by bundling with webpack. On my local environment startup is down to 400 - 500 ms in the "Running Extensions" view. 
I would love to be able to compare Javascript profiles of before and after but  I don't know how to profile extension startup time in vscode. 

#### Changes proposed in this pull request:

**Fixes**: #656 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I was able to build the extension using the npm scripts including compile, watch, and vscode:prepublish. I tested the changes on my environment and was able to download my settings stored in github gist. 
<!--- Include details of your testing environment, tests ran to see how -->
My environment: windows 10; vscode 1.29.1 (user setup)
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and Github Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
