### PR TITLE
Add support for Coder.com (#714)

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -647,9 +647,11 @@ export default class Commons {
     outputChannel.appendLine(`--------------------`);
 
     outputChannel.appendLine(`Files ${upload ? "Upload" : "Download"}ed:`);
-    files.filter(item => item.fileName.indexOf(".") > 0).forEach(item => {
-      outputChannel.appendLine(`  ${item.fileName} > ${item.gistName}`);
-    });
+    files
+      .filter(item => item.fileName.indexOf(".") > 0)
+      .forEach(item => {
+        outputChannel.appendLine(`  ${item.fileName} > ${item.gistName}`);
+      });
 
     outputChannel.appendLine(``);
     outputChannel.appendLine(`Extensions Ignored:`);

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -31,6 +31,7 @@ export class Environment {
   public isInsiders: boolean = false;
   public isOss: boolean = false;
   public isPortable: boolean = false;
+  public isCoderCom: boolean = false;
   public homeDir: string | null = null;
   public USER_FOLDER: string = null;
 
@@ -66,14 +67,17 @@ export class Environment {
     this.isInsiders = /insiders/.test(this.context.asAbsolutePath(""));
     this.isPortable = process.env.VSCODE_PORTABLE ? true : false;
     this.isOss = /\boss\b/.test(this.context.asAbsolutePath(""));
+    this.isCoderCom =
+      vscode.extensions.getExtension("coder.coder") !== undefined;
     const isXdg =
       !this.isInsiders &&
+      !this.isCoderCom &&
       process.platform === "linux" &&
       !!process.env.XDG_DATA_HOME;
     this.homeDir = isXdg
       ? process.env.XDG_DATA_HOME
       : process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"];
-    const configSuffix = `${isXdg ? "" : "."}vscode${
+    const configSuffix = `${isXdg || this.isCoderCom ? "" : "."}vscode${
       this.isInsiders ? "-insiders" : this.isOss ? "-oss" : ""
     }`;
 
@@ -84,10 +88,14 @@ export class Environment {
         this.PATH = process.env.HOME + "/Library/Application Support";
         this.OsType = OsType.Mac;
       } else if (process.platform === "linux") {
-        this.PATH =
-          isXdg && !!process.env.XDG_CONFIG_HOME
-            ? process.env.XDG_CONFIG_HOME
-            : os.homedir() + "/.config";
+        if (!this.isCoderCom) {
+          this.PATH =
+            isXdg && !!process.env.XDG_CONFIG_HOME
+              ? process.env.XDG_CONFIG_HOME
+              : os.homedir() + "/.config";
+        } else {
+          this.PATH = "/tmp";
+        }
         this.OsType = OsType.Linux;
       } else if (process.platform === "win32") {
         this.PATH = process.env.APPDATA;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -528,7 +528,7 @@ export class Sync {
                 const autoUpdate: boolean = vscode.workspace
                   .getConfiguration("extensions")
                   .get("autoUpdate");
-                useCli = autoUpdate;
+                useCli = autoUpdate && !env.isCoderCom;
                 if (useCli) {
                   if (!syncSetting.quietSync) {
                     Commons.outputChannel = vscode.window.createOutputChannel(


### PR DESCRIPTION
#### Short description of what this resolves:

This adds support for the Coder.com VS Code Cloud IDE.

#### Changes proposed in this pull request:

- Added the property `isCoderCom` to `Environment`
- Added some setting overrides in a few places to settings that work for Coder.com
    - Force disable XDG home on Coder.com
    - Remove `.` in configSuffix
    - Force set the settings base path to `/tmp`, which resolves to `/tmp/User`
    - Force manual installation of extensions rather than using the CLI
- Fixed an unrelated TS lint issue so it would pass the linter

**Fixes**: #714

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I tested the plugin on regular VS Code on a Windows machine with a simple settings.json file and 3-4 extensions. The settings file was uploaded from the Windows box and then downloaded into the Coder.com VS Code Cloud IDE using the extension, which worked. The synced extension installations worked as well.

I also tested this in the other direction, uploading the config from Coder.com and downloading to a regular IDE and this also worked.

#### Screenshots (if appropriate):
n/a

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and Github Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
