### PR TITLE
NOMERGE: Always use VSCODE_PORTABLE env when portable

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -107,17 +107,14 @@ export class Environment {
     }
 
     if (this.isPortable) {
+      this.PATH = process.env.VSCODE_PORTABLE;
       if (process.platform === "darwin") {
-        this.PATH = process.env.HOME + "/Library/Application Support";
         this.OsType = OsType.Mac;
       } else if (process.platform === "linux") {
-        this.PATH = process.env.VSCODE_PORTABLE;
         this.OsType = OsType.Linux;
       } else if (process.platform === "win32") {
-        this.PATH = process.env.VSCODE_PORTABLE;
         this.OsType = OsType.Windows;
       } else {
-        this.PATH = process.env.VSCODE_PORTABLE;
         this.OsType = OsType.Linux;
       }
     }


### PR DESCRIPTION
This change seems too simple to me, so I wouldn't find someone else looking over it before merging. I'm wondering, why the extension was set to save to application support in the first place when in portable mode, especially if all other OS's were set to save to VSCODE_PORTABLE?

#### Short description of what this resolves:
This attempts to resolve #684, support portable version on mac

#### Changes proposed in this pull request:

- When in portable mode, macs environment operates the same as other OS's. That is, it writes to VSCODE_PORTABLE instead of application support.

I believe this is the proper behavior, as while portable we don't want any data to be saved to any part of the fine system other than the portable directory.

#### How Has This Been Tested?
Tested on VSCode 1.29.1, running the latest clone of code-settings-sync
macOS 10.14.2, MacBookPro11,3.

Tested initial gist creation, successful settings upload then download.


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and Github Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
