### PR TITLE
Verbose token error on HTTP 401

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -20,19 +20,17 @@ export default class Commons {
   ): void {
     if (error) {
       console.error(error);
-      if (error.code === 500) {
+      if (error.status === 500) {
         message = localize("common.error.connection");
         msgBox = false;
-      } else if (error.code === 4) {
+      } else if (error.status === 401) {
+        msgBox = true;
+        message = localize("common.error.invalidToken");
+      } else if (error.status === 4) {
         message = localize("common.error.canNotSave");
       } else if (error.message) {
         try {
           message = JSON.parse(error.message).message;
-          if (message.toLowerCase() === "bad credentials") {
-            msgBox = true;
-            message = localize("common.error.invalidToken");
-            // vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://github.com/settings/tokens'));
-          }
           if (message.toLowerCase() === "not found") {
             msgBox = true;
             message = localize("common.error.invalidGistId");


### PR DESCRIPTION
#### Short description of what this resolves:
Token errors are properly displayed when getting a HTTP 401 error.

#### Changes proposed in this pull request:
- Display token error on 401, as the current method was displaying generic error for me. Also opens GitHub tokens page on error
> Doesn’t listen for 403 errors as this shouldn’t ever happen with current setup, but we could add later
- Use error.status instead of error.code to avoid depreciation logging

#### How Has This Been Tested?
Tested on VSCode 1.29.1, running the latest clone of code-settings-sync
macOS 10.14.2, MacBookPro11,3.

Tested by revoking my token on Github to see how sync reacts.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and Github Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
