### PR TITLE
Fix loading language bundles and add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "tslint": "^5.11.0",
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.2.2",
-    "vscode": "^1.1.26"
+    "vscode": "^1.1.26",
     "webpack": "^4.26.1",
     "webpack-cli": "^3.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -160,10 +160,13 @@
     "clean-webpack-plugin": "^1.0.0",
     "mocha": "^5.2.0",
     "prettier": "^1.15.3",
+    "ts-loader": "^5.3.0",
     "tslint": "^5.11.0",
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.2.2",
     "vscode": "^1.1.26"
+    "webpack": "^4.26.1",
+    "webpack-cli": "^3.1.2"
   },
   "dependencies": {
     "@octokit/rest": "^16.2.0",

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
+import { extensions } from "vscode";
 
 interface IConfig {
   locale?: string;
@@ -49,7 +50,8 @@ export class Localize {
     const defaultResvoleLanguage = ".nls.json";
     let resolvedLanguage: string = "";
     // TODO: it should read the extension root path from context
-    const rootPath = path.join(__dirname, "..", "..");
+    const rootPath = extensions.getExtension("Shan.code-settings-sync")
+      .extensionPath;
     const file = path.join(rootPath, "package");
     const options = this.options;
 


### PR DESCRIPTION
As discussed in #717 I fixed the issue with the commands not being correctly translated.  It looks like the root path of the extension wasn't being set correctly. 

I packaged the extension with `vsce package` and installed it on my machine with `code --install-extension`. The Advanced Settings menu is now appearing correctly. 