### PR TITLE
WIP : Fix for OSS issues and a couple of bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@
       </a>
       <br>
     </td>
-      <td> 
+      <td>
         <a href="https://opencollective.com/code-settings-sync/order/3848" target="_blank">
             <img src="https://opencollective.com/webpack/donate/button.png?color=blue" width=200 />
         </a>
           <br>
           *2$ Per Month
       </td>
-     
+
   </tr>
 </table>
 <br>
@@ -41,7 +41,7 @@
 
 ## Key Features
 
-``` 
+```
 1. Use your GitHub account token and Gist.
 2. Easy to Upload and Download on one click.
 3. Show a summary page at the end with details about config and extensions effected.
@@ -203,7 +203,7 @@ You can customize the settings in gist settings like:
 
 ```
 1. Configure Gist Id (Environment)
-2. Configure auto upload / download for Github Gist 
+2. Configure auto upload / download for Github Gist
 3. Configure extension sync behaviour
 4. Configure force download
 5. Configure quiet sync
@@ -269,6 +269,7 @@ You can customize the sync:
     ],
     "openTokenLink": true,
     "useCliBaseInstallation": true,
+    "codeCliPath": null,
     "lastUpload": null,
     "lastDownload": null,
     "githubEnterpriseUrl": null,

--- a/package.nls.json
+++ b/package.nls.json
@@ -32,6 +32,7 @@
   "cmd.downloadSettings.info.gotLatestVersion": "Sync : You already have the latest version of saved settings.",
   "cmd.downloadSettings.error.removeExtFail": "Sync : Unable to remove some extensions.",
   "cmd.downloadSettings.error.unableSave": "Sync : Unable to save extension settings file.",
+  "cmd.downloadSettings.error.cliNotFound": "Sync : Unable to find cli path.",
   "cmd.resetSettings.title": "Sync : Reset Extension Settings",
   "cmd.resetSettings.info.resetting": "Sync : Resetting Your Settings.",
   "cmd.resetSettings.info.settingClear": "Sync : Settings Cleared.",
@@ -69,7 +70,7 @@
   "cmd.otherOptions.quietSync.off": "Sync : Summary will be shown upon download / upload.",
   "cmd.otherOptions.warning.tokenNotRequire": "Sync : Settings Sync will not ask for GitHub Token from now on.",
   "cmd.otherOptions.error.toggleFail": "Sync : Unable to Toggle.",
-  "cmd.otherOptions.triggerReset" : "Sync : Do you want to reset the settings ?",
+  "cmd.otherOptions.triggerReset": "Sync : Do you want to reset the settings ?",
   "common.info.installed": "Sync : Settings created, thank you for installing!",
   "common.info.needHelp": "Sync : Need Help configuring this extension?",
   "common.info.excludeFile": "Sync : You can exclude any file / folder for upload and settings for download.",
@@ -101,6 +102,5 @@
   "common.prompt.enterGistId": "Enter Gist Id from previously uploaded settings. You can also set manually in code settings (sync.gist). Press [Enter] or [Esc] to cancel.",
   "common.prompt.enterGithubAccessToken": "You also manually add a token (User Folder / syncLocalSettings.json). Press [Enter] or [Esc] to cancel.",
   "common.prompt.restartCode": "Do you want to reload to apply extensions and configurations?",
-  "common.button.yes" :"Yes"
-  
+  "common.button.yes": "Yes"
 }

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -54,4 +54,6 @@ export class CustomSettings {
   public askGistName: boolean = false;
   public customFiles: { [key: string]: string } = {};
   public hostName: string = null;
+  public useCliBaseInstallation: boolean = true;
+  public codeCliPath: string = null;
 }


### PR DESCRIPTION
* Add custom setting `codeCliPath` for OSS users
* Add usage of the documented `useCliBaseInstallation`
* Fix removing and adding extensions without cli to use lowercase pacakage names

#### Short description of what this resolves:
Fixes issue where the extensions didn't sync under the OSS variant of VS Code.
The problem seemed to stem from the inability of the extension to find the cli of VS Code.

#### Changes proposed in this pull request:
- Let users set the cli path of VS Code in the extension local settings
- Let users disable installation using the `useCliBaseInstallation` settings - which was documented but not used anywhere - which also fixes OSS issues (depending on the next listed change)
- Force installation and deletion of extensions **without cli** to use lowercase folder paths for the extension paths, otherwise VS Code might not recognize the extension is installed, or the extension my not be removed if installed manually.

**Fixes**: #668 

#### How Has This Been Tested?
Ran this on my local dev machine (Solus Linux) where downloading and removing extensions didn't work at all using the OSS variant of VS Code.

Performed multiple installs, uninstalls, uploading and downloading of settings.
Without manually editing the new custom settings, the extension behaves exactly the same, so users who do not have issues will continue normally.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [x] My change requires a change to the documentation and Github Wiki.
- [x] I have updated the documentation and Wiki accordingly.
- [ ] Test with existing Non OSS versions.
