### PR TITLE
Avoid using chokidar (Fix #762)

### DIFF
--- a/install_local.txt
+++ b/install_local.txt
@@ -1,3 +1,3 @@
 npm install
 vsce package
-code --install-extension code-settings-sync-2.9.0.vsix
+code --install-extension code-settings-sync-3.2.4.vsix

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
   "dependencies": {
     "@octokit/rest": "^16.2.0",
     "adm-zip": "^0.4.13",
-    "chokidar": "^2.0.4",
     "fs-extra": "^7.0.1",
     "https-proxy-agent": "^2.2.1",
     "lockfile": "^1.0.4",

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -100,7 +100,7 @@ export default class Commons {
       this.en.ExtensionFolder + "*"
     );
     Commons.configWatcher = vscode.workspace.createFileSystemWatcher(
-      this.en.PATH + "/User/" + "**"
+      this.en.PATH + "/User/" + "{*,*/*,*/*/*}" // depth: 2
     );
 
     // TODO : Uncomment the following lines when code allows feature to update Issue in github code repo - #14444

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -1,5 +1,4 @@
 "use strict";
-import * as chokidar from "chokidar";
 import * as fs from "fs-extra";
 import * as vscode from "vscode";
 import { Environment } from "./environmentPath";
@@ -97,14 +96,12 @@ export default class Commons {
     }
 
     let uploadStopped: boolean = true;
-    Commons.extensionWatcher = chokidar.watch(this.en.ExtensionFolder, {
-      depth: 0,
-      ignoreInitial: true
-    });
-    Commons.configWatcher = chokidar.watch(this.en.PATH + "/User/", {
-      depth: 2,
-      ignoreInitial: true
-    });
+    Commons.extensionWatcher = vscode.workspace.createFileSystemWatcher(
+      this.en.ExtensionFolder + "*"
+    );
+    Commons.configWatcher = vscode.workspace.createFileSystemWatcher(
+      this.en.PATH + "/User/" + "**"
+    );
 
     // TODO : Uncomment the following lines when code allows feature to update Issue in github code repo - #14444
 
@@ -137,7 +134,9 @@ export default class Commons {
     //     }
     // });
 
-    Commons.configWatcher.on("change", async (path: string) => {
+    Commons.configWatcher.onDidChange(async (uri: vscode.Uri) => {
+      const path: string = uri.path;
+
       // check sync is locking
       if (await lockfile.Check(this.en.FILE_SYNC_LOCK)) {
         uploadStopped = false;
@@ -234,10 +233,10 @@ export default class Commons {
 
   public CloseWatch(): void {
     if (Commons.configWatcher != null) {
-      Commons.configWatcher.close();
+      Commons.configWatcher.dispose();
     }
     if (Commons.extensionWatcher != null) {
-      Commons.extensionWatcher.close();
+      Commons.extensionWatcher.dispose();
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:

Fix "Extension host terminated unexpectedly" in Visual Studio Code v1.31.0 with Settings Sync.
( https://github.com/Microsoft/vscode/issues/64981 )

<img width="449" alt="sc 617" src="https://user-images.githubusercontent.com/11713748/52503670-8fd6a180-2c29-11e9-909d-77d21f2073a2.png">

```
dyld: lazy symbol binding failed: Symbol not found: __ZN2v816FunctionTemplate3NewEPNS_7IsolateEPFvRKNS_20FunctionCallbackInfoINS_5ValueEEEENS_5LocalIS4_EENSA_INS_9SignatureEEEiNS_19ConstructorBehaviorENS_14SideEffectTypeE
  Referenced from: /Users/xxx/.vscode/extensions/shan.code-settings-sync-3.2.5/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node
  Expected in: flat namespace
```

It causes by `fsevents`, also `chokidar`.
https://github.com/Microsoft/vscode/issues/65335

So, I remove `chokidar` from this repository, and use **[FileSystemWatcher](https://vshaxe.github.io/vscode-extern/vscode/FileSystemWatcher.html)** .

Thanks: https://github.com/fabiospampinato/vscode-projects-plus/commit/8357ab76b9d600802c71777f280b76240765da48#diff-b9cfc7f2cdf78a7f4b91a753d10865a2


#### Changes proposed in this pull request:

- Remove chokidar
    - disable depth setting because use FileSystemWatcher (sorry...)
- Update install_local.txt

**Fixes**: #762 

#### How Has This Been Tested?

* Put `console.log` to check if pass through StartWatch, onDidChange, CloseWatch.
* Update locale.json (vscode setting), and see starting to upload. Check the gist file if update correctly.
* Update that 5 times, and every upload successfully finished.


#### Screenshots (if appropriate):


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
