### PR TITLE
Fix duplicate gitignore setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 out
 node_modules
+package-lock.json
 *.vsix
-package-lock.json
 *.lock
-package-lock.json
 *.log


### PR DESCRIPTION
#### Short description of what this resolves:

Remove one of `package-lock.json` from `.gitignore`.

#### Changes proposed in this pull request:

- Fix duplicate gitignore setting

**Fixes**: # none

#### How Has This Been Tested?

none

#### Screenshots (if appropriate):

none

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
