### PR TITLE
Remove Disabling of TLS Certificates

### DIFF
--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -81,8 +81,6 @@ export class Environment {
       this.isInsiders ? "-insiders" : this.isOss ? "-oss" : ""
     }`;
 
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
     if (!this.isPortable) {
       if (process.platform === "darwin") {
         this.PATH = process.env.HOME + "/Library/Application Support";


### PR DESCRIPTION
#### Short description of what this resolves:
This removes disabling of TLS certificate validation, which side effects into any other process running within VS Code. 

This closes #776 

If any users report SSL trust issues, they need to fix the issue with VS Code in general, and it should not be handled by an extension. More information on how to properly trust certificates can be found here: https://code.visualstudio.com/docs/setup/network#_ssl-certificates

_Edit:_ Worst case, _the user with the issue_ can turn it off in VS Code if they wish with `--ignore-certificate-errors`, but it should **not** be the default for everyone. 
