### PR TITLE
fix(github): fix octokit warnings

### DIFF
--- a/src/service/githubService.ts
+++ b/src/service/githubService.ts
@@ -44,11 +44,7 @@ export class GitHubService {
   };
 
   constructor(userToken: string, basePath: string) {
-    const githubApiConfig: GitHubApi.Options = {
-      headers: {
-        rejectUnauthorized: false
-      }
-    };
+    const githubApiConfig: GitHubApi.Options = {};
 
     const proxyURL: string =
       vscode.workspace.getConfiguration("http").get("proxy") ||
@@ -61,14 +57,11 @@ export class GitHubService {
     if (proxyURL) {
       githubApiConfig.agent = new HttpsProxyAgent(proxyURL);
     }
-    this.github = new GitHubApi(githubApiConfig);
 
     if (userToken !== null && userToken !== "") {
+      githubApiConfig.auth = `token ${userToken}`;
       try {
-        this.github.authenticate({
-          type: "oauth",
-          token: userToken
-        });
+        this.github = new GitHubApi(githubApiConfig);
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
#### Short description of what this resolves:
Octokit deprecation warnings

#### Changes proposed in this pull request:

- `headers` is deprecated and we shouldn't use it.
- `rejectUnauthorized` set to false is a security issue, and we shouldn't bother to find a workaround for it.
https://github.com/shanalikhan/code-settings-sync/blob/f698ce9112d7d80b3db21b71674feed0475307b3/src/service/githubService.ts#L49
- The `authenticate` function is deprecated and we should use the `auth` option in the constructor of Octokit.
https://github.com/octokit/rest.js#authentication

#### How Has This Been Tested?
Tested with "Launch extension" and `autoUpdate` on and off.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
