### PR TITLE
fix: remove gallery installation check

### DIFF
--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -9,8 +9,6 @@ import * as util from "../util";
 const apiPath =
   "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery";
 
-const extensionDir: string = ".vscode/";
-const extensionDirPortable: string = "/extensions/";
 
 export class ExtensionInformation {
   public static fromJSON(text: string) {
@@ -160,31 +158,29 @@ export class PluginService {
     for (const ext of vscode.extensions.all) {
       console.log(ext.extensionPath);
 
-      if (
-        (ext.extensionPath.includes(extensionDir) ||
-          ext.extensionPath.includes(extensionDirPortable)) && // skip if not install from gallery
-        ext.packageJSON.isBuiltin === false
-      ) {
-        const meta = ext.packageJSON.__metadata || {
-          id: ext.packageJSON.uuid,
-          publisherId: ext.id,
-          publisherDisplayName: ext.packageJSON.publisher
-        };
-        const data = new ExtensionMetadata(
-          meta.galleryApiUrl,
-          meta.id,
-          meta.downloadUrl,
-          meta.publisherId,
-          meta.publisherDisplayName,
-          meta.date
-        );
-        const info = new ExtensionInformation();
-        info.metadata = data;
-        info.name = ext.packageJSON.name;
-        info.publisher = ext.packageJSON.publisher;
-        info.version = ext.packageJSON.version;
-        list.push(info);
+      if (ext.packageJSON.isBuiltin === true) {
+        continue;
       }
+
+      const meta = ext.packageJSON.__metadata || {
+        id: ext.packageJSON.uuid,
+        publisherId: ext.id,
+        publisherDisplayName: ext.packageJSON.publisher
+      };
+      const data = new ExtensionMetadata(
+        meta.galleryApiUrl,
+        meta.id,
+        meta.downloadUrl,
+        meta.publisherId,
+        meta.publisherDisplayName,
+        meta.date
+      );
+      const info = new ExtensionInformation();
+      info.metadata = data;
+      info.name = ext.packageJSON.name;
+      info.publisher = ext.packageJSON.publisher;
+      info.version = ext.packageJSON.version;
+      list.push(info);
     }
 
     return list;


### PR DESCRIPTION
#### Short description of what this resolves:
This solves #756.

#### Changes proposed in this pull request:

- Remove the gallery installation check, because isn't a good validation (It can be "bypassed" and just adds complexity. In the worst-case scenario, the extension will not be installed.

**Fixes**: #756 

#### How Has This Been Tested?
Tested with "Launch extension" and `autoUpdate` on and off.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
