### PR TITLE
Change "bin/bash" to "/bin/bash" when OsType is Linux in pluginService

### DIFF
--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -307,10 +307,10 @@ export class PluginService {
     } else if (osType === OsType.Linux) {
       if (isInsiders) {
         codeLastFolder = "code-insiders";
-        codeCliPath = "bin/code-insiders";
+        codeCliPath = "/bin/code-insiders"; // notice the '/' prefix
       } else {
         codeLastFolder = "code";
-        codeCliPath = "bin/code";
+        codeCliPath =  "/bin/code"; // notice the '/' prefix
       }
     } else if (osType === OsType.Mac) {
       codeLastFolder = "Frameworks";


### PR DESCRIPTION
Change "bin/bash" to "/bin/bash" in pluginService

I suppose this would fix
https://github.com/shanalikhan/code-settings-sync/issues/668

(additional testing needed)

- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
