### PR TITLE
Upload when changes are made

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 "use strict";
 
+import { watchFile } from "fs-extra";
 import * as vscode from "vscode";
 import { init as initLocalize } from "./localize";
 import { Sync } from "./sync";
@@ -41,4 +42,19 @@ export async function activate(context: vscode.ExtensionContext) {
       sync.advance.bind(sync)
     )
   );
+
+  let userPath: string;
+  switch (process.platform) {
+    case "win32":
+      userPath = `${process.env.APPDATA}/Code/User/`;
+      break;
+    case "linux":
+      userPath = `${process.env.HOME}/.config/Code/User/`;
+      break;
+    case "darwin":
+      userPath = `${process.env.HOME}/Library/Application Support/Code/User/`;
+      break;
+  }
+  watchFile(userPath + "settings.json", () => sync.upload());
+  vscode.extensions.onDidChange(() => sync.upload());
 }


### PR DESCRIPTION
#### Short description of what this resolves:
This modification allows for automatically uploading changes when they are made

#### Changes proposed in this pull request:

- Watch for changes in settings.json
- Watch for changes in the extension list

**Fixes**: 1

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I used the built-in debugger to run the extension, and everything was working fine.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
My changes don't affect other areas of the code, it only runs sync.upload() when it detects that an extension has been installed/uninstalled or if settings.json has changed. I tested both downloading and uploading, and everything worked perfectly.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
