### PR TITLE
Fix auto upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
   },
   "devDependencies": {
     "@types/chai": "4.1.7",
+    "@types/chokidar": "^2.1.3",
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.10.4",
@@ -171,6 +172,7 @@
   "dependencies": {
     "@octokit/rest": "^16.16.4",
     "adm-zip": "^0.4.13",
+    "chokidar": "^2.1.5",
     "fs-extra": "^7.0.1",
     "https-proxy-agent": "^2.2.1",
     "lockfile": "^1.0.4",

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -1,13 +1,11 @@
 "use strict";
-import * as fs from "fs-extra";
 import * as vscode from "vscode";
 import { Environment } from "./environmentPath";
 import localize from "./localize";
-import * as lockfile from "./lockfile";
+import { AutoUploadService } from "./service/autoUploadService";
 import { File, FileService } from "./service/fileService";
 import { ExtensionInformation } from "./service/pluginService";
 import { CustomSettings, ExtensionConfig, LocalConfig } from "./setting";
-import { Util } from "./util";
 
 export default class Commons {
   public static outputChannel: vscode.OutputChannel = null;
@@ -72,8 +70,10 @@ export default class Commons {
     }
   }
 
-  private static configWatcher = null;
-  private static extensionWatcher = null;
+  public autoUploadService = new AutoUploadService({
+    en: this.en,
+    commons: this
+  });
 
   public ERROR_MESSAGE: string = localize("common.error.message");
 
@@ -81,164 +81,6 @@ export default class Commons {
     private en: Environment,
     private context: vscode.ExtensionContext
   ) {}
-
-  public async StartWatch(): Promise<void> {
-    const lockExist: boolean = await FileService.FileExists(
-      this.en.FILE_SYNC_LOCK
-    );
-    if (!lockExist) {
-      fs.closeSync(fs.openSync(this.en.FILE_SYNC_LOCK, "w"));
-    }
-
-    // check is sync locking
-    if (await lockfile.Check(this.en.FILE_SYNC_LOCK)) {
-      await lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-    }
-
-    let uploadStopped: boolean = true;
-    Commons.extensionWatcher = vscode.workspace.createFileSystemWatcher(
-      this.en.ExtensionFolder + "*"
-    );
-    Commons.configWatcher = vscode.workspace.createFileSystemWatcher(
-      this.en.PATH + "/User/" + "{*,*/*,*/*/*}" // depth: 2
-    );
-
-    // TODO : Uncomment the following lines when code allows feature to update Issue in github code repo - #14444
-
-    // Commons.extensionWatcher.on('addDir', (path, stat)=> {
-    //     if (uploadStopped) {
-    //         uploadStopped = false;
-    //         this.InitiateAutoUpload().then((resolve) => {
-    //             uploadStopped = resolve;
-    //         }, (reject) => {
-    //             uploadStopped = reject;
-    //         });
-    //     }
-    //     else {
-    //         vscode.window.setStatusBarMessage("");
-    //         vscode.window.setStatusBarMessage("Sync : Updating In Progres... Please Wait.", 3000);
-    //     }
-    // });
-    // Commons.extensionWatcher.on('unlinkDir', (path)=> {
-    //     if (uploadStopped) {
-    //         uploadStopped = false;
-    //         this.InitiateAutoUpload().then((resolve) => {
-    //             uploadStopped = resolve;
-    //         }, (reject) => {
-    //             uploadStopped = reject;
-    //         });
-    //     }
-    //     else {
-    //         vscode.window.setStatusBarMessage("");
-    //         vscode.window.setStatusBarMessage("Sync : Updating In Progres... Please Wait.", 3000);
-    //     }
-    // });
-
-    Commons.configWatcher.onDidChange(async (uri: vscode.Uri) => {
-      const path: string = uri.path;
-
-      // check sync is locking
-      if (await lockfile.Check(this.en.FILE_SYNC_LOCK)) {
-        uploadStopped = false;
-      }
-
-      if (!uploadStopped) {
-        vscode.window.setStatusBarMessage("").dispose();
-        vscode.window.setStatusBarMessage(
-          localize("common.info.updating"),
-          3000
-        );
-        return false;
-      }
-
-      uploadStopped = false;
-      await lockfile.Lock(this.en.FILE_SYNC_LOCK);
-      const settings: ExtensionConfig = this.GetSettings();
-      const customSettings: CustomSettings = await this.GetCustomSettings();
-      if (customSettings == null) {
-        return;
-      }
-
-      let requiredFileChanged: boolean = false;
-      if (
-        customSettings.ignoreUploadFolders.indexOf("workspaceStorage") === -1
-      ) {
-        requiredFileChanged =
-          path.indexOf(this.en.FILE_SYNC_LOCK_NAME) === -1 &&
-          path.indexOf(".DS_Store") === -1 &&
-          path.indexOf(this.en.FILE_CUSTOMIZEDSETTINGS_NAME) === -1;
-      } else {
-        requiredFileChanged =
-          path.indexOf(this.en.FILE_SYNC_LOCK_NAME) === -1 &&
-          path.indexOf("workspaceStorage") === -1 &&
-          path.indexOf(".DS_Store") === -1 &&
-          path.indexOf(this.en.FILE_CUSTOMIZEDSETTINGS_NAME) === -1;
-      }
-
-      console.log("Sync : File Change Detected On : " + path);
-
-      if (requiredFileChanged) {
-        if (settings.autoUpload) {
-          if (
-            customSettings.ignoreUploadFolders.indexOf("workspaceStorage") > -1
-          ) {
-            const fileType: string = path.substring(
-              path.lastIndexOf("."),
-              path.length
-            );
-            if (fileType.indexOf("json") === -1) {
-              console.log(
-                "Sync : Cannot Initiate Auto-upload on This File (Not JSON)."
-              );
-              uploadStopped = true;
-              return;
-            }
-          }
-
-          console.log("Sync : Initiating Auto-upload For File : " + path);
-          this.InitiateAutoUpload(path)
-            .then(isDone => {
-              uploadStopped = isDone;
-              return lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-            })
-            .catch(() => {
-              uploadStopped = true;
-              return lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-            });
-        }
-      } else {
-        uploadStopped = true;
-        await lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-      }
-    });
-  }
-
-  public async InitiateAutoUpload(path: string): Promise<boolean> {
-    vscode.window.setStatusBarMessage("").dispose();
-    vscode.window.setStatusBarMessage(
-      localize("common.info.initAutoUpload"),
-      5000
-    );
-
-    await Util.Sleep(3000);
-
-    vscode.commands.executeCommand(
-      "extension.updateSettings",
-      "forceUpdate",
-      path
-    );
-
-    return true;
-  }
-
-  public CloseWatch(): void {
-    if (Commons.configWatcher != null) {
-      Commons.configWatcher.dispose();
-    }
-    if (Commons.extensionWatcher != null) {
-      Commons.extensionWatcher.dispose();
-    }
-  }
 
   public async InitalizeSettings(
     askToken: boolean,

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -268,7 +268,7 @@ export default class Commons {
 
   public CloseWatch(): void {
     if (Commons.configWatcher) {
-      Commons.configWatcher = null;
+      Commons.configWatcher.close();
     }
   }
 

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -70,17 +70,27 @@ export default class Commons {
     }
   }
 
-  public autoUploadService = new AutoUploadService({
-    en: this.en,
-    commons: this
-  });
+  public autoUploadService: AutoUploadService;
 
   public ERROR_MESSAGE: string = localize("common.error.message");
 
   constructor(
     private en: Environment,
     private context: vscode.ExtensionContext
-  ) {}
+  ) {
+    this.InitializeAutoUpload();
+  }
+
+  public async InitializeAutoUpload() {
+    const ignored = await AutoUploadService.GetIgnoredItems(
+      await this.GetCustomSettings()
+    );
+    this.autoUploadService = new AutoUploadService({
+      en: this.en,
+      commons: this,
+      ignored
+    });
+  }
 
   public async InitalizeSettings(
     askToken: boolean,

--- a/src/service/autoUploadService.ts
+++ b/src/service/autoUploadService.ts
@@ -1,5 +1,4 @@
 import { watch } from "chokidar";
-import { resolve } from "path";
 import * as vscode from "vscode";
 import Commons from "../commons";
 import { Environment } from "../environmentPath";

--- a/src/service/autoUploadService.ts
+++ b/src/service/autoUploadService.ts
@@ -11,13 +11,7 @@ export class AutoUploadService {
   public watching = false;
   private watcher = watch(this.options.en.USER_FOLDER, {
     depth: 2,
-    ignored: this.options.commons.GetCustomSettings().ignoredItems.map(item => {
-      if (FileService.IsDirectory(resolve(this.options.en.USER_FOLDER, item))) {
-        return `**/${item}/**`;
-      } else {
-        return `**/${item}`;
-      }
-    })
+    ignored: this.GetIgnoredItems()
   });
 
   constructor(private options: { en: Environment; commons: Commons }) {
@@ -35,6 +29,17 @@ export class AutoUploadService {
         return await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
       }
     });
+  }
+
+  public GetIgnoredItems() {
+    const ignoredItems = [];
+    this.options.commons.GetCustomSettings().then(customSettings => {
+      ignoredItems.push(
+        customSettings.ignoreUploadFolders.map(folder => `**/${folder}/**`),
+        customSettings.ignoreUploadFiles.map(file => `**/${file}`)
+      );
+    });
+    return ignoredItems;
   }
 
   public async StartWatching() {

--- a/src/service/autoUploadService.ts
+++ b/src/service/autoUploadService.ts
@@ -2,8 +2,10 @@ import { watch } from "chokidar";
 import * as vscode from "vscode";
 import Commons from "../commons";
 import { Environment } from "../environmentPath";
+import localize from "../localize";
 import lockfile from "../lockfile";
 import { CustomSettings } from "../setting";
+import { Util } from "../util";
 import { FileService } from "./fileService";
 
 export class AutoUploadService {
@@ -29,13 +31,15 @@ export class AutoUploadService {
         console.log("Sync: Extensions changed");
         if (await lockfile.Check(this.options.en.FILE_SYNC_LOCK)) {
           return;
+        } else {
+          await lockfile.Lock(this.options.en.FILE_SYNC_LOCK);
         }
-        await lockfile.Lock(this.options.en.FILE_SYNC_LOCK);
         const customSettings: CustomSettings = await this.options.commons.GetCustomSettings();
         if (customSettings) {
           await this.InitiateAutoUpload();
         }
-        return await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
+        await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
+        return;
       }
     });
   }
@@ -77,6 +81,14 @@ export class AutoUploadService {
   }
 
   private async InitiateAutoUpload() {
+    vscode.window.setStatusBarMessage("").dispose();
+    vscode.window.setStatusBarMessage(
+      localize("common.info.initAutoUpload"),
+      5000
+    );
+
+    await Util.Sleep(5000);
+
     vscode.commands.executeCommand("extension.updateSettings", "forceUpdate");
   }
 }

--- a/src/service/autoUploadService.ts
+++ b/src/service/autoUploadService.ts
@@ -1,0 +1,79 @@
+import { watch } from "chokidar";
+import { resolve } from "path";
+import * as vscode from "vscode";
+import Commons from "../commons";
+import { Environment } from "../environmentPath";
+import lockfile from "../lockfile";
+import { CustomSettings } from "../setting";
+import { FileService } from "./fileService";
+
+export class AutoUploadService {
+  public watching = false;
+  private watcher = watch(this.options.en.USER_FOLDER, {
+    depth: 2,
+    ignored: this.options.commons.GetCustomSettings().ignoredItems.map(item => {
+      if (FileService.IsDirectory(resolve(this.options.en.USER_FOLDER, item))) {
+        return `**/${item}/**`;
+      } else {
+        return `**/${item}`;
+      }
+    })
+  });
+
+  constructor(private options: { en: Environment; commons: Commons }) {
+    vscode.extensions.onDidChange(async () => {
+      if (this.watching) {
+        console.log("Sync: Extensions changed");
+        if (await lockfile.Check(this.options.en.FILE_SYNC_LOCK)) {
+          return;
+        }
+        await lockfile.Lock(this.options.en.FILE_SYNC_LOCK);
+        const customSettings: CustomSettings = await this.options.commons.GetCustomSettings();
+        if (customSettings) {
+          await this.InitiateAutoUpload();
+        }
+        return await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
+      }
+    });
+  }
+
+  public async StartWatching() {
+    this.StopWatching();
+
+    this.watching = true;
+
+    this.watcher.addListener("all", async (event: string, path: string) => {
+      console.log(
+        `Sync: ${FileService.ExtractFileName(path)} triggered event: ${event}`
+      );
+      if (await lockfile.Check(this.options.en.FILE_SYNC_LOCK)) {
+        return;
+      } else {
+        await lockfile.Lock(this.options.en.FILE_SYNC_LOCK);
+      }
+
+      const customSettings: CustomSettings = await this.options.commons.GetCustomSettings();
+      if (customSettings) {
+        const fileType: string = path
+          .substring(path.lastIndexOf("."), path.length)
+          .slice(1);
+        if (customSettings.supportedFileExtensions.indexOf(fileType) !== -1) {
+          await this.InitiateAutoUpload();
+        }
+      }
+      await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
+      return;
+    });
+  }
+
+  public StopWatching() {
+    if (this.watcher) {
+      this.watcher.removeAllListeners();
+    }
+    this.watching = false;
+  }
+
+  private async InitiateAutoUpload() {
+    vscode.commands.executeCommand("extension.updateSettings", "forceUpdate");
+  }
+}

--- a/src/service/fileService.ts
+++ b/src/service/fileService.ts
@@ -1,228 +1,17 @@
 "use strict";
 
 import * as fs from "fs-extra";
-import * as $path from "path";
+import * as path from "path";
 
 export class File {
   constructor(
-    public filename: string,
+    public fileName: string,
     public content: string,
-    public path: string,
+    public filePath: string,
     public gistName: string
-  ) {
-    //
-  }
+  ) {}
 }
 export class FileService {
-  public static CUSTOMIZED_SYNC_PREFIX = "|customized_sync|";
-
-  public static ReadFile(path: string): string {
-    try {
-      return fs.readFileSync(path, { encoding: "utf8" });
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
-  }
-
-  public static IsDirectory(path: string): boolean {
-    try {
-      return fs.lstatSync(path).isDirectory();
-    } catch (err) {
-      return false;
-    }
-  }
-
-  public static GetFile(path: string): File {
-    if (FileService.FileExists(path)) {
-      return null;
-    }
-
-    const content = FileService.ReadFile(path);
-
-    if (content === null) {
-      return null;
-    }
-
-    const pathFromUser: string = path.substring(
-      path.lastIndexOf("User") + 5,
-      path.length
-    );
-
-    const arr: string[] = pathFromUser.indexOf("/")
-      ? pathFromUser.split("/")
-      : pathFromUser.split($path.sep);
-
-    let gistName: string = "";
-
-    arr.forEach((element, index) => {
-      if (index < arr.length - 1) {
-        gistName += element + "|";
-      } else {
-        gistName += element;
-      }
-    });
-
-    return new File(this.ExtractFileName(path), content, path, gistName);
-  }
-
-  public static WriteFile(path: string, data: string): boolean {
-    if (!data) {
-      console.error(
-        new Error("Unable to write file. FilePath :" + path + " Data :" + data)
-      );
-      return false;
-    }
-    try {
-      fs.writeFileSync(path, data);
-      return true;
-    } catch (err) {
-      console.error(err);
-      return false;
-    }
-  }
-
-  public static ListFiles(
-    directory: string,
-    depth: number,
-    fullDepth: number,
-    fileExtensions: string[]
-  ): File[] {
-    const fileList = fs.readdirSync(directory);
-
-    const files: File[] = [];
-    for (const fileName of fileList) {
-      const path: string = directory.concat(fileName);
-      if (FileService.IsDirectory(path)) {
-        if (depth < fullDepth) {
-          for (const element of FileService.ListFiles(
-            path + "/",
-            depth + 1,
-            fullDepth,
-            fileExtensions
-          )) {
-            files.push(element);
-          }
-        }
-      } else {
-        const hasExtension: boolean = path.lastIndexOf(".") > 0;
-        let allowedFile: boolean = false;
-        if (hasExtension) {
-          const extension: string = path
-            .substr(path.lastIndexOf(".") + 1, path.length)
-            .toLowerCase();
-          allowedFile = fileExtensions.filter(m => m === extension).length > 0;
-        } else {
-          allowedFile = fileExtensions.filter(m => m === "").length > 0;
-        }
-
-        if (allowedFile) {
-          files.push(FileService.GetFile(path));
-        }
-      }
-    }
-
-    return files;
-  }
-
-  public static async CreateDirTree(
-    userFolder: string,
-    fileName: string
-  ): Promise<string> {
-    let path: string = userFolder;
-    let result: string;
-
-    if (fileName.indexOf("|") > -1) {
-      const paths: string[] = fileName.split("|");
-
-      for (let i = 0; i < paths.length - 1; i++) {
-        const element = paths[i];
-        path += element + "/";
-        await FileService.CreateDirectory(path);
-      }
-
-      result = path + paths[paths.length - 1];
-      return result;
-    } else {
-      result = path + fileName;
-
-      return result;
-    }
-  }
-
-  public static DeleteFile(path: string): boolean {
-    try {
-      const stat: boolean = FileService.FileExists(path);
-      if (stat) {
-        fs.unlinkSync(path);
-      }
-      return true;
-    } catch (err) {
-      console.error("Unable to delete file. File Path is :" + path);
-      return false;
-    }
-  }
-
-  public static FileExists(path: string): boolean {
-    try {
-      fs.accessSync(path, fs.constants.F_OK);
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }
-
-  public static GetCustomFile(path: string): File {
-    const fileExists = FileService.FileExists(path);
-
-    if (!fileExists) {
-      return null;
-    }
-
-    const content = FileService.ReadFile(path);
-
-    if (content === null) {
-      return null;
-    }
-
-    const filename = this.ExtractFileName(path);
-    const gistName: string = FileService.CUSTOMIZED_SYNC_PREFIX + filename;
-
-    return new File(filename, content, path, gistName);
-  }
-
-  public static CreateDirectory(name: string): boolean {
-    try {
-      fs.mkdirSync(name);
-      return true;
-    } catch (err) {
-      if (err.code === "EEXIST") {
-        return false;
-      }
-      throw err;
-    }
-  }
-
-  public static CreateCustomDirTree(filePath: string): string {
-    const dir = $path.dirname(filePath);
-    const fileExists = FileService.FileExists(dir);
-
-    if (!fileExists) {
-      fs.mkdirsSync(dir);
-    }
-    return filePath;
-  }
-
-  public static ExtractFileName(fullPath: string): string {
-    return $path.basename(fullPath);
-  }
-
-  public static ConcatPath(...filePaths: string[]): string {
-    return filePaths.join($path.sep);
-  }
-}
-
-export class FileServiceAsync {
   public static CUSTOMIZED_SYNC_PREFIX = "|customized_sync|";
 
   public static async ReadFile(filePath: string): Promise<string> {
@@ -244,14 +33,17 @@ export class FileServiceAsync {
     }
   }
 
-  public static async GetFile(filePath: string): Promise<File> {
-    const fileExists: boolean = await FileServiceAsync.FileExists(filePath);
+  public static async GetFile(
+    filePath: string,
+    fileName: string
+  ): Promise<File> {
+    const fileExists: boolean = await FileService.FileExists(filePath);
 
     if (!fileExists) {
       return null;
     }
 
-    const content = await FileServiceAsync.ReadFile(filePath);
+    const content = await FileService.ReadFile(filePath);
 
     if (content === null) {
       return null;
@@ -264,7 +56,7 @@ export class FileServiceAsync {
 
     const arr: string[] = pathFromUser.indexOf("/")
       ? pathFromUser.split("/")
-      : pathFromUser.split($path.sep);
+      : pathFromUser.split(path.sep);
 
     let gistName: string = "";
 
@@ -276,12 +68,7 @@ export class FileServiceAsync {
       }
     });
 
-    const file: File = new File(
-      this.ExtractFileName(filePath),
-      content,
-      filePath,
-      gistName
-    );
+    const file: File = new File(fileName, content, filePath, gistName);
     return file;
   }
 
@@ -317,9 +104,9 @@ export class FileServiceAsync {
     const files: File[] = [];
     for (const fileName of fileList) {
       const fullPath: string = directory.concat(fileName);
-      if (await FileServiceAsync.IsDirectory(fullPath)) {
+      if (await FileService.IsDirectory(fullPath)) {
         if (depth < fullDepth) {
-          for (const element of await FileServiceAsync.ListFiles(
+          for (const element of await FileService.ListFiles(
             fullPath + "/",
             depth + 1,
             fullDepth,
@@ -341,7 +128,7 @@ export class FileServiceAsync {
         }
 
         if (allowedFile) {
-          const file: File = await FileServiceAsync.GetFile(fullPath);
+          const file: File = await FileService.GetFile(fullPath, fileName);
           files.push(file);
         }
       }
@@ -363,7 +150,7 @@ export class FileServiceAsync {
       for (let i = 0; i < paths.length - 1; i++) {
         const element = paths[i];
         fullPath += element + "/";
-        await FileServiceAsync.CreateDirectory(fullPath);
+        await FileService.CreateDirectory(fullPath);
       }
 
       result = fullPath + paths[paths.length - 1];
@@ -377,7 +164,7 @@ export class FileServiceAsync {
 
   public static async DeleteFile(filePath: string): Promise<boolean> {
     try {
-      const stat: boolean = await FileServiceAsync.FileExists(filePath);
+      const stat: boolean = await FileService.FileExists(filePath);
       if (stat) {
         await fs.unlink(filePath);
       }
@@ -413,28 +200,28 @@ export class FileServiceAsync {
     filePath: string,
     fileName: string
   ): Promise<File> {
-    const fileExists: boolean = await FileServiceAsync.FileExists(filePath);
+    const fileExists: boolean = await FileService.FileExists(filePath);
 
     if (!fileExists) {
       return null;
     }
 
-    const content = await FileServiceAsync.ReadFile(filePath);
+    const content = await FileService.ReadFile(filePath);
 
     if (content === null) {
       return null;
     }
 
     // for identifing Customized Sync file
-    const gistName: string = FileServiceAsync.CUSTOMIZED_SYNC_PREFIX + fileName;
+    const gistName: string = FileService.CUSTOMIZED_SYNC_PREFIX + fileName;
 
     const file: File = new File(fileName, content, filePath, gistName);
     return file;
   }
 
   public static async CreateCustomDirTree(filePath: string): Promise<string> {
-    const dir = $path.dirname(filePath);
-    const fileExists = await FileServiceAsync.FileExists(dir);
+    const dir = path.dirname(filePath);
+    const fileExists = await FileService.FileExists(dir);
 
     if (!fileExists) {
       // mkdir recursively
@@ -445,10 +232,10 @@ export class FileServiceAsync {
   }
 
   public static ExtractFileName(fullPath: string): string {
-    return $path.basename(fullPath);
+    return path.basename(fullPath);
   }
 
   public static ConcatPath(...filePaths: string[]): string {
-    return filePaths.join($path.sep);
+    return filePaths.join(path.sep);
   }
 }

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -155,8 +155,6 @@ export class PluginService {
     const list: ExtensionInformation[] = [];
 
     for (const ext of vscode.extensions.all) {
-      console.log(ext.extensionPath);
-
       if (ext.packageJSON.isBuiltin === true) {
         continue;
       }

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -24,10 +24,6 @@ export class CloudSetting {
   public extensionVersion: string = "v" + Environment.getVersion();
 }
 
-export class KeyValue<T, S> {
-  constructor(public Key: T, public Value: S) {}
-}
-
 export class CustomSettings {
   public ignoreUploadFiles: string[] = [
     "projects.json",
@@ -39,6 +35,20 @@ export class CustomSettings {
   ];
   public ignoreUploadFolders: string[] = ["workspaceStorage"];
   public ignoreExtensions: string[] = [];
+  public ignoredItems = [
+    ".git",
+    "syncLocalSettings.json",
+    "sync.lock",
+    "workspaceStorage",
+    "globalStorage/state.vscdb",
+    "globalStorage/state.vscdb.backup",
+    "projects.json",
+    "projects_cache_vscode.json",
+    "projects_cache_git.json",
+    "projects_cache_svn.json",
+    "gpm_projects.json",
+    "gpm-recentItems.json"
+  ];
   public ignoreUploadSettings: string[] = [];
   public replaceCodeSettings: { [key: string]: any } = {};
   public gistDescription: string = "Visual Studio Code Settings Sync Gist";

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -30,6 +30,8 @@ export class KeyValue<T, S> {
 
 export class CustomSettings {
   public ignoreUploadFiles: string[] = [
+    "state.vscdb",
+    "state.vscdb.backup",
     "syncLocalSettings.json",
     "projects.json",
     "projects_cache_vscode.json",

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -24,6 +24,10 @@ export class CloudSetting {
   public extensionVersion: string = "v" + Environment.getVersion();
 }
 
+export class KeyValue<T, S> {
+  constructor(public Key: T, public Value: S) {}
+}
+
 export class CustomSettings {
   public ignoreUploadFiles: string[] = [
     "projects.json",
@@ -35,20 +39,6 @@ export class CustomSettings {
   ];
   public ignoreUploadFolders: string[] = ["workspaceStorage"];
   public ignoreExtensions: string[] = [];
-  public ignoredItems = [
-    ".git",
-    "syncLocalSettings.json",
-    "sync.lock",
-    "workspaceStorage",
-    "globalStorage/state.vscdb",
-    "globalStorage/state.vscdb.backup",
-    "projects.json",
-    "projects_cache_vscode.json",
-    "projects_cache_git.json",
-    "projects_cache_svn.json",
-    "gpm_projects.json",
-    "gpm-recentItems.json"
-  ];
   public ignoreUploadSettings: string[] = [];
   public replaceCodeSettings: { [key: string]: any } = {};
   public gistDescription: string = "Visual Studio Code Settings Sync Gist";

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -33,6 +33,8 @@ export class CustomSettings {
     "state.vscdb",
     "state.vscdb.backup",
     "syncLocalSettings.json",
+    ".DS_Store",
+    "sync.lock",
     "projects.json",
     "projects_cache_vscode.json",
     "projects_cache_git.json",

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -30,6 +30,7 @@ export class KeyValue<T, S> {
 
 export class CustomSettings {
   public ignoreUploadFiles: string[] = [
+    "syncLocalSettings.json",
     "projects.json",
     "projects_cache_vscode.json",
     "projects_cache_git.json",

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -49,11 +49,24 @@ export class Sync {
       const gistAvailable: boolean =
         startUpSetting.gist != null && startUpSetting.gist !== "";
 
-      if (gistAvailable === true && startUpSetting.autoDownload === true) {
-        vscode.commands.executeCommand("extension.downloadSettings");
-      }
-      if (startUpSetting.autoUpload && tokenAvailable && gistAvailable) {
-        return globalCommonService.autoUploadService.StartWatching();
+      if (gistAvailable) {
+        if (startUpSetting.autoDownload) {
+          vscode.commands
+            .executeCommand("extension.downloadSettings")
+            .then(() => {
+              if (
+                startUpSetting.autoUpload &&
+                tokenAvailable &&
+                gistAvailable
+              ) {
+                return globalCommonService.autoUploadService.StartWatching();
+              }
+            });
+        } else {
+          if (startUpSetting.autoUpload && tokenAvailable && gistAvailable) {
+            return globalCommonService.autoUploadService.StartWatching();
+          }
+        }
       }
     }
   }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -48,13 +48,7 @@ export class Sync {
         startUpSetting.gist != null && startUpSetting.gist !== "";
 
       if (gistAvailable === true && startUpSetting.autoDownload === true) {
-        vscode.commands
-          .executeCommand("extension.downloadSettings")
-          .then(() => {
-            if (startUpSetting.autoUpload && tokenAvailable && gistAvailable) {
-              return globalCommonService.StartWatch();
-            }
-          });
+        vscode.commands.executeCommand("extension.downloadSettings");
       }
       if (startUpSetting.autoUpload && tokenAvailable && gistAvailable) {
         return globalCommonService.StartWatch();
@@ -65,6 +59,7 @@ export class Sync {
    * Upload setting to github gist
    */
   public async upload(): Promise<void> {
+    console.log("uploading");
     const args = arguments;
     const env = new Environment(this.context);
     const common = new Commons(env, this.context);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -18,6 +18,8 @@ import {
 
 import PragmaUtil from "./pragmaUtil";
 
+let globalCommonService: Commons;
+
 export class Sync {
   constructor(private context: vscode.ExtensionContext) {}
   /**
@@ -25,7 +27,7 @@ export class Sync {
    */
   public async bootstrap(): Promise<void> {
     const env = new Environment(this.context);
-    const globalCommonService = new Commons(env, this.context);
+    globalCommonService = new Commons(env, this.context);
     // if lock file not exist
     // then create it
     if (!(await FileService.FileExists(env.FILE_SYNC_LOCK))) {
@@ -48,16 +50,10 @@ export class Sync {
         startUpSetting.gist != null && startUpSetting.gist !== "";
 
       if (gistAvailable === true && startUpSetting.autoDownload === true) {
-        vscode.commands
-          .executeCommand("extension.downloadSettings")
-          .then(() => {
-            if (startUpSetting.autoUpload && tokenAvailable && gistAvailable) {
-              return globalCommonService.StartWatch();
-            }
-          });
+        vscode.commands.executeCommand("extension.downloadSettings");
       }
       if (startUpSetting.autoUpload && tokenAvailable && gistAvailable) {
-        return globalCommonService.StartWatch();
+        return globalCommonService.autoUploadService.StartWatching();
       }
     }
   }
@@ -67,17 +63,16 @@ export class Sync {
   public async upload(): Promise<void> {
     const args = arguments;
     const env = new Environment(this.context);
-    const common = new Commons(env, this.context);
     let github: GitHubService = null;
     let localConfig: LocalConfig = new LocalConfig();
     const allSettingFiles: File[] = [];
     let uploadedExtensions: ExtensionInformation[] = [];
     const ignoredExtensions: ExtensionInformation[] = [];
     const dateNow = new Date();
-    common.CloseWatch();
+    globalCommonService.autoUploadService.StopWatching();
 
     try {
-      localConfig = await common.InitalizeSettings(true, false);
+      localConfig = await globalCommonService.InitalizeSettings(true, false);
       localConfig.publicGist = false;
       if (args.length > 0) {
         if (args[0] === "publicGIST") {
@@ -93,7 +88,7 @@ export class Sync {
       await startGitProcess(localConfig.extConfig, localConfig.customConfig);
       // await common.SetIgnoredSettings(ignoreSettings);
     } catch (error) {
-      Commons.LogException(error, common.ERROR_MESSAGE, true);
+      Commons.LogException(error, globalCommonService.ERROR_MESSAGE, true);
       return;
     }
 
@@ -203,7 +198,7 @@ export class Sync {
           }
         }
       } else {
-        Commons.LogException(null, common.ERROR_MESSAGE, true);
+        Commons.LogException(null, globalCommonService.ERROR_MESSAGE, true);
         return;
       }
 
@@ -245,7 +240,7 @@ export class Sync {
       try {
         if (syncSetting.gist == null || syncSetting.gist === "") {
           if (customSettings.askGistName) {
-            customSettings.gistDescription = await common.AskGistName();
+            customSettings.gistDescription = await globalCommonService.AskGistName();
           }
           newGIST = true;
           const gistID = await github.CreateEmptyGIST(
@@ -312,14 +307,16 @@ export class Sync {
           return;
         }
       } catch (err) {
-        Commons.LogException(err, common.ERROR_MESSAGE, true);
+        Commons.LogException(err, globalCommonService.ERROR_MESSAGE, true);
         return;
       }
 
       if (completed) {
         try {
-          const settingsUpdated = await common.SaveSettings(syncSetting);
-          const customSettingsUpdated = await common.SetCustomSettings(
+          const settingsUpdated = await globalCommonService.SaveSettings(
+            syncSetting
+          );
+          const customSettingsUpdated = await globalCommonService.SetCustomSettings(
             customSettings
           );
           if (settingsUpdated && customSettingsUpdated) {
@@ -339,7 +336,7 @@ export class Sync {
             }
 
             if (!syncSetting.quietSync) {
-              common.ShowSummaryOutput(
+              globalCommonService.ShowSummaryOutput(
                 true,
                 allSettingFiles,
                 null,
@@ -356,11 +353,11 @@ export class Sync {
               );
             }
             if (syncSetting.autoUpload) {
-              common.StartWatch();
+              globalCommonService.autoUploadService.StartWatching();
             }
           }
         } catch (err) {
-          Commons.LogException(err, common.ERROR_MESSAGE, true);
+          Commons.LogException(err, globalCommonService.ERROR_MESSAGE, true);
         }
       }
     }
@@ -370,15 +367,14 @@ export class Sync {
    */
   public async download(): Promise<void> {
     const env = new Environment(this.context);
-    const common = new Commons(env, this.context);
     let localSettings: LocalConfig = new LocalConfig();
-    common.CloseWatch();
+    globalCommonService.autoUploadService.StopWatching();
 
     try {
-      localSettings = await common.InitalizeSettings(true, true);
+      localSettings = await globalCommonService.InitalizeSettings(true, true);
       await StartDownload(localSettings.extConfig, localSettings.customConfig);
     } catch (err) {
-      Commons.LogException(err, common.ERROR_MESSAGE, true);
+      Commons.LogException(err, globalCommonService.ERROR_MESSAGE, true);
       return;
     }
 
@@ -612,7 +608,11 @@ export class Sync {
                     // TODO : add Name attribute in File and show information message here with name , when required.
                   })
                   .catch(err => {
-                    Commons.LogException(err, common.ERROR_MESSAGE, true);
+                    Commons.LogException(
+                      err,
+                      globalCommonService.ERROR_MESSAGE,
+                      true
+                    );
                     return;
                   })
               );
@@ -622,13 +622,15 @@ export class Sync {
       }
 
       await Promise.all(actionList);
-      const settingsUpdated = await common.SaveSettings(syncSetting);
-      const customSettingsUpdated = await common.SetCustomSettings(
+      const settingsUpdated = await globalCommonService.SaveSettings(
+        syncSetting
+      );
+      const customSettingsUpdated = await globalCommonService.SetCustomSettings(
         customSettings
       );
       if (settingsUpdated && customSettingsUpdated) {
         if (!syncSetting.quietSync) {
-          common.ShowSummaryOutput(
+          globalCommonService.ShowSummaryOutput(
             false,
             updatedFiles,
             deletedExtensions,
@@ -664,7 +666,7 @@ export class Sync {
           }
         }
         if (syncSetting.autoUpload) {
-          common.StartWatch();
+          globalCommonService.autoUploadService.StartWatching();
         }
       } else {
         vscode.window.showErrorMessage(
@@ -977,7 +979,7 @@ export class Sync {
       await handlerMap[index]();
       if (settingChanged) {
         if (selectedItem === 1) {
-          common.CloseWatch();
+          globalCommonService.autoUploadService.StopWatching();
         }
         await common
           .SaveSettings(setting)


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes auto-upload by using Chokidar and `vscode.extensions.onDidChange` instead of `vscode.FileSystemWatcher`, which only works on files in the current workspace.

#### Changes proposed in this pull request:

- Use Chokidar instead of `vscode.FileSystemWatcher` to detect changes in user settings
- Use VSC's onDidChange event to check for changes in extensions
- Unlock lock file when returning from the `StartWatch()` function after locking to prevent it from becoming unusable

**Fixes**: 3

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested it by installing/uninstalling extensions and modifying my settings. I can confirm that the changes don't affect any other areas in the code, and it uploads and downloads successfully.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
