### PR TITLE
fix bug in ignoreUploadFolder

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -184,10 +184,10 @@ export class Sync {
           contentFiles = contentFiles.filter((contentFile: File) => {
             const matchedFolders = customSettings.ignoreUploadFolders.filter(
               folder => {
-                return contentFile.filePath.indexOf(folder) === -1;
+                return contentFile.filePath.indexOf(folder) !== -1;
               }
             );
-            return matchedFolders.length > 0;
+            return matchedFolders.length === 0;
           });
         }
         const customFileKeys: string[] = Object.keys(


### PR DESCRIPTION
#### Short description of what this resolves:
Fix a bug where it wasn't correctly ignoring folders if there was more than 1 folder in the list.

#### Changes proposed in this pull request:
- change filter to fit function definition -- check if a file has a *matched* ignoreFolder

**Fixes**: #

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Add folder to ignored folder list. Check files are properly ignored.

#### Screenshots (if appropriate):
Before Fix:
![beforecode](https://user-images.githubusercontent.com/10459400/55050683-fe2bc380-501f-11e9-9c9d-8b38d2f94ba3.PNG)

After Fix:
![aftercode](https://user-images.githubusercontent.com/10459400/55050685-04ba3b00-5020-11e9-8df9-028e5699fd30.PNG)
#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
