### PR TITLE
WIP. Create GUI for Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
   "devDependencies": {
     "@types/chai": "4.1.7",
     "@types/fs-extra": "^5.0.5",
+    "@types/lodash": "^4.14.123",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.10.4",
     "chai": "^4.2.0",
@@ -172,8 +173,10 @@
     "@octokit/rest": "^16.16.4",
     "adm-zip": "^0.4.13",
     "fs-extra": "^7.0.1",
+    "html-loader": "^0.5.5",
     "https-proxy-agent": "^2.2.1",
     "lockfile": "^1.0.4",
+    "lodash": "^4.17.11",
     "temp": "^0.9.0"
   }
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -36,6 +36,7 @@
   "cmd.resetSettings.info.resetting": "Sync : Resetting Your Settings.",
   "cmd.resetSettings.info.settingClear": "Sync : Settings Cleared.",
   "cmd.otherOptions.title": "Sync : Advanced Options",
+  "cmd.otherOptions.openSettings": "Sync : Open Settings",
   "cmd.otherOptions.editLocalSetting": "Sync : Edit Extension Local Settings",
   "cmd.otherOptions.shareSetting": "Sync : Share Settings with Public GIST",
   "cmd.otherOptions.shareSetting.beforeConfirm": "Sync : This will remove current GIST and upload settings on new public GIST. Do you want to continue?",
@@ -69,7 +70,7 @@
   "cmd.otherOptions.quietSync.off": "Sync : Summary will be shown upon download / upload.",
   "cmd.otherOptions.warning.tokenNotRequire": "Sync : Settings Sync will not ask for GitHub Token from now on.",
   "cmd.otherOptions.error.toggleFail": "Sync : Unable to Toggle.",
-  "cmd.otherOptions.triggerReset" : "Sync : Do you want to reset the settings ?",
+  "cmd.otherOptions.triggerReset": "Sync : Do you want to reset the settings ?",
   "common.info.installed": "Sync : Settings created, thank you for installing!",
   "common.info.needHelp": "Sync : Need Help configuring this extension?",
   "common.info.excludeFile": "Sync : You can exclude any file / folder for upload and settings for download.",
@@ -101,6 +102,5 @@
   "common.prompt.enterGistId": "Enter Gist Id from previously uploaded settings. You can also set manually in code settings (sync.gist). Press [Enter] or [Esc] to cancel.",
   "common.prompt.enterGithubAccessToken": "You also manually add a token (User Folder / syncLocalSettings.json). Press [Enter] or [Esc] to cancel.",
   "common.prompt.restartCode": "Do you want to reload to apply extensions and configurations?",
-  "common.button.yes" :"Yes"
-  
+  "common.button.yes": "Yes"
 }

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -1,5 +1,6 @@
 "use strict";
 import * as fs from "fs-extra";
+import { has, set } from "lodash";
 import * as vscode from "vscode";
 import { Environment } from "./environmentPath";
 import localize from "./localize";
@@ -8,6 +9,15 @@ import { File, FileService } from "./service/fileService";
 import { ExtensionInformation } from "./service/pluginService";
 import { CustomSettings, ExtensionConfig, LocalConfig } from "./setting";
 import { Util } from "./util";
+
+// tslint:disable-next-line: no-var-requires
+const SettingsView = require("html-loader!./ui/settings/settings.html");
+
+enum SettingType {
+  TextInput,
+  Checkbox,
+  TextArea
+}
 
 export default class Commons {
   public static outputChannel: vscode.OutputChannel = null;
@@ -77,10 +87,115 @@ export default class Commons {
 
   public ERROR_MESSAGE: string = localize("common.error.message");
 
+  private customizableSettings = [
+    {
+      name: "Hostname (optional)",
+      placeholder: "Enter Hostname",
+      type: SettingType.TextInput,
+      correspondingSetting: "hostName"
+    },
+    {
+      name: "Ignored Files",
+      placeholder: "Enter one file per line",
+      type: SettingType.TextArea,
+      correspondingSetting: "ignoreUploadFiles"
+    },
+    {
+      name: "Ignored Folders",
+      placeholder: "Enter one folder per line",
+      type: SettingType.TextArea,
+      correspondingSetting: "ignoreUploadFolders"
+    },
+    {
+      name: "Ignored Extensions",
+      placeholder: "Enter one extension per line (full name)",
+      type: SettingType.TextArea,
+      correspondingSetting: "ignoreExtensions"
+    },
+    {
+      name: "Supported File Extensions",
+      placeholder: "Enter one file extension per line",
+      type: SettingType.TextArea,
+      correspondingSetting: "supportedFileExtensions"
+    },
+    {
+      name: "Access Token",
+      placeholder: "Enter Token",
+      type: SettingType.TextInput,
+      correspondingSetting: "token"
+    },
+    {
+      name: "Gist Description",
+      placeholder: "Enter Gist Description",
+      type: SettingType.TextInput,
+      correspondingSetting: "gistDescription"
+    },
+    {
+      name: "GitHub Enterprise URL (optional)",
+      placeholder: "Enter GitHub Enterprise URL",
+      type: SettingType.TextInput,
+      correspondingSetting: "githubEnterpriseUrl"
+    },
+    {
+      name: "Ask Gist Name",
+      placeholder: "",
+      type: SettingType.Checkbox,
+      correspondingSetting: "askGistName"
+    },
+    {
+      name: "Download Public Gist",
+      placeholder: "",
+      type: SettingType.Checkbox,
+      correspondingSetting: "downloadPublicGist"
+    },
+    {
+      name: "Open Token Link",
+      placeholder: "",
+      type: SettingType.Checkbox,
+      correspondingSetting: "openTokenLink"
+    }
+  ];
+
   constructor(
     private en: Environment,
     private context: vscode.ExtensionContext
   ) {}
+
+  public async OpenSettingsPage() {
+    const customSettings = await this.GetCustomSettings();
+    const content: string = SettingsView.replace(
+      "@CURRENT_DATA",
+      JSON.stringify(customSettings)
+    ).replace("@SETTINGS_MAP", JSON.stringify(this.customizableSettings));
+    const settingsPanel = vscode.window.createWebviewPanel(
+      "syncSettings",
+      "Sync Settings",
+      vscode.ViewColumn.One,
+      {
+        retainContextWhenHidden: true,
+        enableScripts: true
+      }
+    );
+    settingsPanel.webview.html = content;
+    settingsPanel.webview.onDidReceiveMessage(message =>
+      this.ReceiveSettingChange(message)
+    );
+  }
+
+  public async ReceiveSettingChange(message: {
+    command: string;
+    text: string;
+  }) {
+    let value: any = message.text;
+    if (message.text === "true" || message.text === "false") {
+      value = message.text === "true";
+    }
+    const customSettings = await this.GetCustomSettings();
+    if (has(customSettings, message.command)) {
+      set(customSettings, message.command, value);
+      this.SetCustomSettings(customSettings);
+    }
+  }
 
   public async StartWatch(): Promise<void> {
     const lockExist: boolean = await FileService.FileExists(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -753,6 +753,7 @@ export class Sync {
     const gistAvailable: boolean = setting.gist != null && setting.gist !== "";
 
     const items: string[] = [
+      "cmd.otherOptions.openSettings",
       "cmd.otherOptions.editLocalSetting",
       "cmd.otherOptions.shareSetting",
       "cmd.otherOptions.downloadSetting",
@@ -782,6 +783,9 @@ export class Sync {
 
     const handlerMap = {
       0: async () => {
+        common.OpenSettingsPage();
+      },
+      1: async () => {
         const file: vscode.Uri = vscode.Uri.file(env.FILE_CUSTOMIZEDSETTINGS);
         fs.openSync(file.fsPath, "r");
         const document = await vscode.workspace.openTextDocument(file);
@@ -791,7 +795,7 @@ export class Sync {
           true
         );
       },
-      1: async () => {
+      2: async () => {
         // share public gist
         const answer = await vscode.window.showInformationMessage(
           localize("cmd.otherOptions.shareSetting.beforeConfirm"),
@@ -807,26 +811,26 @@ export class Sync {
           await common.SetCustomSettings(customSettings);
         }
       },
-      2: async () => {
+      3: async () => {
         // Download Settings from Public GIST
         selectedItem = 2;
         customSettings.downloadPublicGist = true;
         settingChanged = true;
         await common.SetCustomSettings(customSettings);
       },
-      3: async () => {
+      4: async () => {
         // toggle force download
         selectedItem = 3;
         settingChanged = true;
         setting.forceDownload = !setting.forceDownload;
       },
-      4: async () => {
+      5: async () => {
         // toggle auto upload
         selectedItem = 4;
         settingChanged = true;
         setting.autoUpload = !setting.autoUpload;
       },
-      5: async () => {
+      6: async () => {
         // auto download on startup
         selectedItem = 5;
         settingChanged = true;
@@ -841,7 +845,7 @@ export class Sync {
 
         setting.autoDownload = !setting.autoDownload;
       },
-      6: async () => {
+      7: async () => {
         // page summary toggle
         selectedItem = 6;
         settingChanged = true;
@@ -852,7 +856,7 @@ export class Sync {
         }
         setting.quietSync = !setting.quietSync;
       },
-      7: async () => {
+      8: async () => {
         // preserve
         const options: vscode.InputBoxOptions = {
           ignoreFocusOut: true,
@@ -880,7 +884,7 @@ export class Sync {
           }
         }
       },
-      8: async () => {
+      9: async () => {
         // add customized sync file
         const options: vscode.InputBoxOptions = {
           ignoreFocusOut: true,
@@ -903,7 +907,7 @@ export class Sync {
           }
         }
       },
-      9: async () => {
+      10: async () => {
         // Import customized sync file to workspace
         const customFiles = await this.getCustomFilesFromGist(
           customSettings,
@@ -947,7 +951,7 @@ export class Sync {
           }
         }
       },
-      10: async () => {
+      11: async () => {
         vscode.commands.executeCommand(
           "vscode.open",
           vscode.Uri.parse(
@@ -955,7 +959,7 @@ export class Sync {
           )
         );
       },
-      11: async () => {
+      12: async () => {
         vscode.commands.executeCommand(
           "vscode.open",
           vscode.Uri.parse(
@@ -963,7 +967,7 @@ export class Sync {
           )
         );
       },
-      12: async () => {
+      13: async () => {
         vscode.commands.executeCommand(
           "vscode.open",
           vscode.Uri.parse(

--- a/src/ui/settings/settings.html
+++ b/src/ui/settings/settings.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,900"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <title>Sync Settings</title>
+  </head>
+  <body>
+    <div style="height: 70px"></div>
+    <div class="container">
+      <div class="jumbotron">
+        <h2 class="display-4">Sync Settings</h2>
+        <hr class="my-4" />
+        <form id="root"></form>
+      </div>
+    </div>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      String.prototype.replaceAll = function(search, replacement) {
+        var target = this;
+        return target.replace(new RegExp(search, "g"), replacement);
+      };
+
+      function appendHTML(parent, html) {
+        var div = document.createElement("div");
+        div.innerHTML = html;
+        while (div.children.length > 0) {
+          parent.appendChild(div.children[0]);
+        }
+        div.remove();
+      }
+    </script>
+    <script>
+      const settings = JSON.parse(`@CURRENT_DATA`);
+      const settingsMap = JSON.parse(`@SETTINGS_MAP`);
+      const vscode = acquireVsCodeApi();
+
+      const textInputTemplate = `<div class="form-group">
+            <label for="setting:@correspondingSetting"
+              >@name</label
+            >
+            <input
+              type="text"
+              class="form-control text"
+              id="setting:@correspondingSetting"
+              placeholder="@placeholder"
+              setting="@correspondingSetting"
+            />
+          </div>`;
+
+      const checkboxTemplate = `<div class="custom-control custom-checkbox my-1 mr-sm-2">
+            <input
+              class="custom-control-input checkbox"
+              type="checkbox"
+              id="setting:@correspondingSetting"
+              setting="@correspondingSetting"
+            />
+            <label for="setting:@correspondingSetting" class="custom-control-label">
+              @name
+            </label>
+          </div>`;
+
+      const textareaTemplate = `<div class="form-group">
+            <label for="setting:@correspondingSetting"
+              >@name</label
+            >
+            <textarea
+              class="form-control textarea"
+              id="setting:@correspondingSetting"
+              rows="3"
+              data-min-rows="3"
+              placeholder="@placeholder"
+              setting="@correspondingSetting"
+            ></textarea>
+          </div>`;
+
+      const parent = document.getElementById("root");
+      settingsMap.forEach(settingMap => {
+        let template;
+        switch (settingMap.type) {
+          case 0:
+            template = textInputTemplate;
+            break;
+          case 1:
+            template = checkboxTemplate;
+            break;
+          case 2:
+            template = textareaTemplate;
+            break;
+        }
+        const html = template
+          .replaceAll("@name", settingMap.name)
+          .replaceAll("@placeholder", settingMap.placeholder)
+          .replaceAll("@correspondingSetting", settingMap.correspondingSetting);
+        appendHTML(parent, html);
+      });
+
+      $(document).ready(function() {
+        $(".text")
+          .each((i, el) => {
+            $(el).val(_.get(settings, $(el).attr("setting")));
+          })
+          .change(function() {
+            let val = $(this).val();
+            vscode.postMessage({
+              command: $(this).attr("setting"),
+              text: val
+            });
+          });
+        $(".checkbox")
+          .each((i, el) => {
+            $(el).prop("checked", _.get(settings, $(el).attr("setting")));
+          })
+          .change(function() {
+            let val = $(this).is(":checked");
+            vscode.postMessage({
+              command: $(this).attr("setting"),
+              text: val
+            });
+          });
+        $(".textarea")
+          .each((i, el) => {
+            let str = "";
+            _.get(settings, $(el).attr("setting")).forEach(
+              item => (str += item + "\n")
+            );
+            $(el).val(str);
+          })
+          .change(function() {
+            let val = [];
+            $(this)
+              .val()
+              .split("\n")
+              .forEach(item => {
+                if (item !== "") {
+                  val.push(item);
+                }
+              });
+            vscode.postMessage({
+              command: $(this).attr("setting"),
+              text: val
+            });
+          });
+      });
+    </script>
+    <style>
+      html,
+      body {
+        background-color: rgb(37, 37, 37);
+        font-family: "Roboto", sans-serif !important;
+      }
+      .jumbotron > .display-4 {
+        font-weight: 900;
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
#### Short description of what this resolves:
A GUI for settings would allow users to change settings in a more beginner-friendly way.

#### Changes proposed in this pull request:

- Implement an extendable GUI for changing settings

**Improvements**: 1

#### How Has This Been Tested?
I have tested this by changing different settings and checking to see if they updated in the JSON file.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25834068/55454493-f8d8f680-5594-11e9-9050-3d00302e11e9.png)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [x] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
- [ ] Make a **good looking** UI