### PR TITLE
Switch to vscode-chokidar [Updated]

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
   },
   "devDependencies": {
     "@types/chai": "4.1.7",
-    "@types/chokidar": "^2.1.3",
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.13.0",
@@ -171,10 +170,10 @@
   },
   "dependencies": {
     "@octokit/rest": "^16.16.4",
-    "chokidar": "^2.1.5",
     "fs-extra": "^7.0.1",
     "https-proxy-agent": "^2.2.1",
     "lockfile": "^1.0.4",
-    "temp": "^0.9.0"
+    "temp": "^0.9.0",
+    "vscode-chokidar": "^1.6.5"
   }
 }

--- a/src/service/autoUploadService.ts
+++ b/src/service/autoUploadService.ts
@@ -1,5 +1,5 @@
-import { watch } from "chokidar";
 import * as vscode from "vscode";
+import { watch } from "vscode-chokidar";
 import Commons from "../commons";
 import { Environment } from "../environmentPath";
 import localize from "../localize";


### PR DESCRIPTION
#### Short description of what this resolves:
This fixes issues with extension host being killed.

#### Changes proposed in this pull request:

- Use the `vscode-chokidar` package instead of `chokidar`

**Fixes**: #827 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by @wescoder and @Spacebody

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.