### PR TITLE
Add support for disabled extensions

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -508,7 +508,8 @@ export default class Commons {
       outputChannel.appendLine(`  No extensions ignored.`);
     } else {
       ignoredExtensions.forEach(extn => {
-        outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+        const version = extn.enabled ? `v${extn.version}` : "disabled";
+        outputChannel.appendLine(`  ${extn.name} ${version}`);
       });
     }
 
@@ -522,7 +523,8 @@ export default class Commons {
         outputChannel.appendLine(`  No extensions removed.`);
       } else {
         removedExtensions.forEach(extn => {
-          outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+          const version = extn.enabled ? `v${extn.version}` : "disabled";
+          outputChannel.appendLine(`  ${extn.name} ${version}`);
         });
       }
     }
@@ -536,7 +538,8 @@ export default class Commons {
       }
 
       addedExtensions.forEach(extn => {
-        outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+        const version = extn.enabled ? `v${extn.version}` : "disabled";
+        outputChannel.appendLine(`  ${extn.name} ${version}`);
       });
     }
 

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { OsType } from "../enums";
+import { Util } from "../util";
 
 export class ExtensionInformation {
   public static fromJSON(text: string) {
@@ -267,39 +268,12 @@ export class PluginService {
     notificationCallBack("TOTAL EXTENSIONS : " + missingList.length);
     notificationCallBack("");
     notificationCallBack("");
-    let myExt: string = process.argv0;
-    console.log(myExt);
-    let codeLastFolder = "";
-    let codeCliPath = "";
-    if (osType === OsType.Windows) {
-      if (isInsiders) {
-        codeLastFolder = "Code - Insiders";
-        codeCliPath = "bin/code-insiders";
-      } else {
-        codeLastFolder = "Code";
-        codeCliPath = "bin/code";
-      }
-    } else if (osType === OsType.Linux) {
-      if (isInsiders) {
-        codeLastFolder = "code-insiders";
-        codeCliPath = "bin/code-insiders";
-      } else {
-        codeLastFolder = "code";
-        codeCliPath = "bin/code";
-      }
-    } else if (osType === OsType.Mac) {
-      codeLastFolder = "Frameworks";
-      codeCliPath = "Resources/app/bin/code";
-    }
-    myExt =
-      '"' +
-      myExt.substr(0, myExt.lastIndexOf(codeLastFolder)) +
-      codeCliPath +
-      '"';
+    const codeCli = Util.GetCodeCli(osType, isInsiders);
+    console.log(codeCli);
     for (let i = 0; i < missingList.length; i++) {
       const missExt = missingList[i];
       const name = missExt.publisher + "." + missExt.name;
-      const extensionCli = myExt + " --install-extension " + name;
+      const extensionCli = codeCli + " --install-extension " + name;
       notificationCallBack(extensionCli);
       try {
         const installed = await new Promise<boolean>(res => {

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -11,14 +11,16 @@ export class ExtensionInformation {
     // TODO: JSON.parse may throw error
     // Throw custom error should be more friendly
     const obj = JSON.parse(text);
-    const meta = new ExtensionMetadata(
-      obj.meta.galleryApiUrl,
-      obj.meta.id,
-      obj.meta.downloadUrl,
-      obj.meta.publisherId,
-      obj.meta.publisherDisplayName,
-      obj.meta.date
-    );
+    const meta = obj.meta
+      ? new ExtensionMetadata(
+          obj.meta.galleryApiUrl,
+          obj.meta.id,
+          obj.meta.downloadUrl,
+          obj.meta.publisherId,
+          obj.meta.publisherDisplayName,
+          obj.meta.date
+        )
+      : null;
     const item = new ExtensionInformation();
     item.metadata = meta;
     item.name = obj.name;
@@ -35,14 +37,16 @@ export class ExtensionInformation {
       // Throw custom error should be more friendly
       const list = JSON.parse(text);
       list.forEach(obj => {
-        const meta = new ExtensionMetadata(
-          obj.metadata.galleryApiUrl,
-          obj.metadata.id,
-          obj.metadata.downloadUrl,
-          obj.metadata.publisherId,
-          obj.metadata.publisherDisplayName,
-          obj.metadata.date
-        );
+        const meta = obj.metadata
+          ? new ExtensionMetadata(
+              obj.metadata.galleryApiUrl,
+              obj.metadata.id,
+              obj.metadata.downloadUrl,
+              obj.metadata.publisherId,
+              obj.metadata.publisherDisplayName,
+              obj.metadata.date
+            )
+          : null;
         const item = new ExtensionInformation();
         item.metadata = meta;
         item.name = obj.name;

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -81,11 +81,13 @@ export class ExtensionMetadata {
 export class PluginService {
   public static GetMissingExtensions(
     remoteExt: string,
-    ignoredExtensions: string[]
+    ignoredExtensions: string[],
+    osType: OsType,
+    isInsiders: boolean
   ) {
     const hashset = {};
     const remoteList = ExtensionInformation.fromJSONList(remoteExt);
-    const localList = this.CreateExtensionList();
+    const localList = this.CreateExtensionList(osType, isInsiders);
     const missingList: ExtensionInformation[] = [];
 
     for (const ext of localList) {
@@ -107,9 +109,11 @@ export class PluginService {
 
   public static GetDeletedExtensions(
     remoteList: ExtensionInformation[],
-    ignoredExtensions: string[]
+    ignoredExtensions: string[],
+    osType: OsType,
+    isInsiders: boolean
   ) {
-    const localList = this.CreateExtensionList();
+    const localList = this.CreateExtensionList(osType, isInsiders);
     const deletedList: ExtensionInformation[] = [];
 
     // for (var i = 0; i < remoteList.length; i++) {
@@ -229,12 +233,16 @@ export class PluginService {
   public static async DeleteExtensions(
     extensionsJson: string,
     extensionFolder: string,
-    ignoredExtensions: string[]
+    ignoredExtensions: string[],
+    osType: OsType,
+    isInsiders: boolean
   ): Promise<ExtensionInformation[]> {
     const remoteList = ExtensionInformation.fromJSONList(extensionsJson);
     const deletedList = PluginService.GetDeletedExtensions(
       remoteList,
-      ignoredExtensions
+      ignoredExtensions,
+      osType,
+      isInsiders
     );
     const deletedExt: ExtensionInformation[] = [];
 
@@ -269,7 +277,9 @@ export class PluginService {
     let addedExtensions: ExtensionInformation[] = [];
     const missingList = PluginService.GetMissingExtensions(
       extensions,
-      ignoredExtensions
+      ignoredExtensions,
+      osType,
+      insiders
     );
     if (missingList.length === 0) {
       notificationCallBack("Sync : No Extensions needs to be installed.");

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -47,6 +47,7 @@ export class ExtensionInformation {
         item.name = obj.name;
         item.publisher = obj.publisher;
         item.version = obj.version;
+        item.enabled = obj.enabled;
 
         if (item.name !== "code-settings-sync") {
           extList.push(item);
@@ -63,6 +64,7 @@ export class ExtensionInformation {
   public name: string;
   public version: string;
   public publisher: string;
+  public enabled: boolean = true;
 }
 
 export class ExtensionMetadata {

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -24,6 +24,7 @@ export class ExtensionInformation {
     item.name = obj.name;
     item.publisher = obj.publisher;
     item.version = obj.version;
+    item.enabled = obj.enabled;
     return item;
   }
 
@@ -333,6 +334,26 @@ export class PluginService {
               " INSTALLED.",
             true
           );
+          notificationCallBack("");
+
+          if (!missExt.enabled) {
+            const disabled = await new Promise<boolean>(res => {
+              const command = `${codeCli} --disable-extension ${name}`;
+              notificationCallBack(command);
+              exec(command, (err, stdout, stderr) => {
+                if (!stdout && (err || stderr)) {
+                  notificationCallBack(err || stderr);
+                  res(false);
+                }
+                notificationCallBack(stdout);
+                res(true);
+              });
+            });
+            if (disabled) {
+              notificationCallBack("EXTENSION DISABLED.");
+            }
+          }
+
           notificationCallBack("");
           notificationCallBack("");
           addedExtensions.push(missExt);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -132,7 +132,10 @@ export class Sync {
       // var remoteList = ExtensionInformation.fromJSONList(file.content);
       // var deletedList = PluginService.GetDeletedExtensions(uploadedExtensions);
       if (syncSetting.syncExtensions) {
-        uploadedExtensions = PluginService.CreateExtensionList();
+        uploadedExtensions = PluginService.CreateExtensionList(
+          env.OsType,
+          env.isInsiders
+        );
         if (
           customSettings.ignoreExtensions &&
           customSettings.ignoreExtensions.length > 0
@@ -521,7 +524,9 @@ export class Sync {
                   deletedExtensions = await PluginService.DeleteExtensions(
                     content,
                     env.ExtensionFolder,
-                    ignoredExtensions
+                    ignoredExtensions,
+                    env.OsType,
+                    env.isInsiders
                   );
                 } catch (uncompletedExtensions) {
                   vscode.window.showErrorMessage(

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,6 +8,8 @@ import * as _temp from "temp";
 import * as url from "url";
 import * as vscode from "vscode";
 
+import { OsType } from "./enums";
+
 interface IHeaders {
   [key: string]: string;
 }
@@ -32,6 +34,41 @@ if (proxy) {
 }
 
 export class Util {
+  public static GetCodeCli(osType: OsType, isInsiders: boolean): string {
+    let codeCli: string = process.argv0;
+    let codeLastFolder = "";
+    let codeCliPath = "";
+
+    if (osType === OsType.Windows) {
+      if (isInsiders) {
+        codeLastFolder = "Code - Insiders";
+        codeCliPath = "bin/code-insiders";
+      } else {
+        codeLastFolder = "Code";
+        codeCliPath = "bin/code";
+      }
+    } else if (osType === OsType.Linux) {
+      if (isInsiders) {
+        codeLastFolder = "code-insiders";
+        codeCliPath = "bin/code-insiders";
+      } else {
+        codeLastFolder = "code";
+        codeCliPath = "bin/code";
+      }
+    } else if (osType === OsType.Mac) {
+      codeLastFolder = "Frameworks";
+      codeCliPath = "Resources/app/bin/code";
+    }
+
+    codeCli =
+      '"' +
+      codeCli.substr(0, codeCli.lastIndexOf(codeLastFolder)) +
+      codeCliPath +
+      '"';
+
+    return codeCli;
+  }
+
   public static HttpPostJson(path: string, obj: any, headers: IHeaders) {
     return new Promise<string>((resolve, reject) => {
       const item = url.parse(path);


### PR DESCRIPTION
#### Short description of what this resolves:

Takes account disabled extensions when uploading or downloading the gist file.

#### Changes proposed in this pull request:

- `CreateExtensionList` now uses `code --list-extensions` to get enabled and disabled extensions;
- When `download` executes it verifies the extension object's enabled property . If false calls `code --disable-extension` with the extension name.

**Fixes**: #143 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on a Macbook with VSCode.

- Open `code-settings-sync` project;
- Disable an extension; 
- While debugging (`F5`) inside this branch execute `Upload / Update settings`;
- Then check in your gist if the current extension is disabled;
- Leave the debugging mode and uninstall the same extension;
- Open the debugging mode and execute `Download settings`;
- Check if it installs the extension and disables it automatically.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
