### PR TITLE
Utilized pragmaUtil Functions for kb.json file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,10 @@ src/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
+node_modules
+.github
+debug.log
+scripts
+tslint.json
+webpack.config.js
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/Shan.code-settings-sync.svg)](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) [![Travis](https://img.shields.io/travis/rust-lang/rust.svg)](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) [![Master course](https://img.shields.io/badge/Supported%20by-VSCode%20Power%20User%20Course%20%E2%86%92-gray.svg?colorA=444444&colorB=4F44D6)](https://t.co/8BEMyhpKU5?amp=1)
 
+#### v3.2.8 - April 04,2019
+
+* Bug : auto upload doesn't work when make change on settings [#801](https://github.com/shanalikhan/code-settings-sync/issues/801) -  Thanks for PR [#807](https://github.com/shanalikhan/code-settings-sync/pull/807) by [@arnohovhannisyan](https://github.com/arnohovhannisyan)
+* Bug : Auto Upload / Download : Disable change detection for workspace storage folder [#708](https://github.com/shanalikhan/code-settings-sync/issues/708) -  Thanks for PR [#811](https://github.com/shanalikhan/code-settings-sync/pull/811) by [@knyhle](https://github.com/knyhle)
+* Pretiffy Custom Settings JSON -  Thanks for PR [#812](https://github.com/shanalikhan/code-settings-sync/pull/812) by [@knyhle](https://github.com/knyhle)
+* Improvement - Remove manual visx package installation in favour of extension download by CLI [#820](https://github.com/shanalikhan/code-settings-sync/issues/820)
+* Improvement - Remove replaceCodeSettings from Settings Sync configurations [#805](https://github.com/shanalikhan/code-settings-sync/issues/805)
+
 #### v3.2.7 - March 06,2019
+
 * Bug : Fixing Extensions Sync on Windows [#789](https://github.com/shanalikhan/code-settings-sync/issues/789) -  Thanks for PR [#791](https://github.com/shanalikhan/code-settings-sync/pull/791) by [@LuisUrrutia](https://github.com/LuisUrrutia)
 
 #### v3.2.6 - March 05,2019

--- a/README.md
+++ b/README.md
@@ -257,9 +257,6 @@ You can customize the sync:
     "ignoreExtensions": [
         "ignored_extension_name"
     ],
-    "replaceCodeSettings": {
-        "http.proxy": "http://my.proxy.address:8080"
-    },
     "gistDescription": "Visual Studio Code Settings Sync Gist",
     "version": 310,
     "token": "YOUR_GITHUB_TOKEN_HERE",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "email": "shanalikhan@hotmail.com"
   },
   "engines": {
-    "vscode": "^1.31.1"
+    "vscode": "^1.32.3"
   },
   "categories": [
     "Other"
@@ -165,13 +165,12 @@
     "tslint": "^5.13.1",
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.3.3333",
-    "vscode": "^1.1.30",
+    "vscode": "^1.1.33",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
     "@octokit/rest": "^16.16.4",
-    "adm-zip": "^0.4.13",
     "chokidar": "^2.1.5",
     "fs-extra": "^7.0.1",
     "https-proxy-agent": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "code-settings-sync",
   "displayName": "Settings Sync",
   "description": "Synchronize Settings, Snippets, Themes, File Icons, Launch, Keybindings, Workspaces and Extensions Across Multiple Machines Using GitHub Gist.",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "icon": "images/cloud.png",
   "publisher": "Shan",
   "author": {
@@ -156,18 +156,18 @@
     "@types/chokidar": "^2.1.3",
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^11.10.4",
+    "@types/node": "^11.13.0",
     "chai": "^4.2.0",
-    "clean-webpack-plugin": "^2.0.0",
-    "mocha": "^6.0.0",
+    "clean-webpack-plugin": "^2.0.1",
+    "mocha": "^6.0.2",
     "prettier": "^1.16.4",
     "ts-loader": "^5.3.3",
-    "tslint": "^5.13.1",
+    "tslint": "^5.15.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.4.1",
     "vscode": "^1.1.33",
     "webpack": "^4.29.6",
-    "webpack-cli": "^3.2.3"
+    "webpack-cli": "^3.3.0"
   },
   "dependencies": {
     "@octokit/rest": "^16.16.4",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
   },
   "devDependencies": {
     "@types/chai": "4.1.7",
+    "@types/chokidar": "^2.1.3",
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.10.4",
@@ -171,6 +172,7 @@
   "dependencies": {
     "@octokit/rest": "^16.16.4",
     "adm-zip": "^0.4.13",
+    "chokidar": "^2.1.5",
     "fs-extra": "^7.0.1",
     "https-proxy-agent": "^2.2.1",
     "lockfile": "^1.0.4",

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -334,7 +334,7 @@ export default class Commons {
       delete json.ignoreUploadSettings;
       await FileService.WriteFile(
         this.en.FILE_CUSTOMIZEDSETTINGS,
-        JSON.stringify(json)
+        JSON.stringify(json, null, 4)
       );
       return true;
     } catch (e) {

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -33,7 +33,7 @@ export default class Commons {
             message = localize("common.error.invalidGistId");
           }
         } catch (error) {
-          // message = error.message;
+          //  message = error.message;
         }
       }
     }

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -1,13 +1,11 @@
 "use strict";
-import * as fs from "fs-extra";
 import * as vscode from "vscode";
 import { Environment } from "./environmentPath";
 import localize from "./localize";
-import * as lockfile from "./lockfile";
+import { AutoUploadService } from "./service/autoUploadService";
 import { File, FileService } from "./service/fileService";
 import { ExtensionInformation } from "./service/pluginService";
 import { CustomSettings, ExtensionConfig, LocalConfig } from "./setting";
-import { Util } from "./util";
 
 export default class Commons {
   public static outputChannel: vscode.OutputChannel = null;
@@ -72,172 +70,26 @@ export default class Commons {
     }
   }
 
-  private static configWatcher = null;
-  private static extensionWatcher = null;
+  public autoUploadService: AutoUploadService;
 
   public ERROR_MESSAGE: string = localize("common.error.message");
 
   constructor(
     private en: Environment,
     private context: vscode.ExtensionContext
-  ) {}
+  ) {
+    this.InitializeAutoUpload();
+  }
 
-  public async StartWatch(): Promise<void> {
-    const lockExist: boolean = await FileService.FileExists(
-      this.en.FILE_SYNC_LOCK
+  public async InitializeAutoUpload() {
+    const ignored = await AutoUploadService.GetIgnoredItems(
+      await this.GetCustomSettings()
     );
-    if (!lockExist) {
-      fs.closeSync(fs.openSync(this.en.FILE_SYNC_LOCK, "w"));
-    }
-
-    // check is sync locking
-    if (await lockfile.Check(this.en.FILE_SYNC_LOCK)) {
-      await lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-    }
-
-    let uploadStopped: boolean = true;
-    Commons.extensionWatcher = vscode.workspace.createFileSystemWatcher(
-      this.en.ExtensionFolder + "*"
-    );
-    Commons.configWatcher = vscode.workspace.createFileSystemWatcher(
-      this.en.PATH + "/User/" + "{*,*/*,*/*/*}" // depth: 2
-    );
-
-    // TODO : Uncomment the following lines when code allows feature to update Issue in github code repo - #14444
-
-    // Commons.extensionWatcher.on('addDir', (path, stat)=> {
-    //     if (uploadStopped) {
-    //         uploadStopped = false;
-    //         this.InitiateAutoUpload().then((resolve) => {
-    //             uploadStopped = resolve;
-    //         }, (reject) => {
-    //             uploadStopped = reject;
-    //         });
-    //     }
-    //     else {
-    //         vscode.window.setStatusBarMessage("");
-    //         vscode.window.setStatusBarMessage("Sync : Updating In Progres... Please Wait.", 3000);
-    //     }
-    // });
-    // Commons.extensionWatcher.on('unlinkDir', (path)=> {
-    //     if (uploadStopped) {
-    //         uploadStopped = false;
-    //         this.InitiateAutoUpload().then((resolve) => {
-    //             uploadStopped = resolve;
-    //         }, (reject) => {
-    //             uploadStopped = reject;
-    //         });
-    //     }
-    //     else {
-    //         vscode.window.setStatusBarMessage("");
-    //         vscode.window.setStatusBarMessage("Sync : Updating In Progres... Please Wait.", 3000);
-    //     }
-    // });
-
-    Commons.configWatcher.onDidChange(async (uri: vscode.Uri) => {
-      const path: string = uri.path;
-
-      // check sync is locking
-      if (await lockfile.Check(this.en.FILE_SYNC_LOCK)) {
-        uploadStopped = false;
-      }
-
-      if (!uploadStopped) {
-        vscode.window.setStatusBarMessage("").dispose();
-        vscode.window.setStatusBarMessage(
-          localize("common.info.updating"),
-          3000
-        );
-        return false;
-      }
-
-      uploadStopped = false;
-      await lockfile.Lock(this.en.FILE_SYNC_LOCK);
-      const settings: ExtensionConfig = this.GetSettings();
-      const customSettings: CustomSettings = await this.GetCustomSettings();
-      if (customSettings == null) {
-        return;
-      }
-
-      let requiredFileChanged: boolean = false;
-      if (
-        customSettings.ignoreUploadFolders.indexOf("workspaceStorage") === -1
-      ) {
-        requiredFileChanged =
-          path.indexOf(this.en.FILE_SYNC_LOCK_NAME) === -1 &&
-          path.indexOf(".DS_Store") === -1 &&
-          path.indexOf(this.en.FILE_CUSTOMIZEDSETTINGS_NAME) === -1;
-      } else {
-        requiredFileChanged =
-          path.indexOf(this.en.FILE_SYNC_LOCK_NAME) === -1 &&
-          path.indexOf("workspaceStorage") === -1 &&
-          path.indexOf(".DS_Store") === -1 &&
-          path.indexOf(this.en.FILE_CUSTOMIZEDSETTINGS_NAME) === -1;
-      }
-
-      console.log("Sync : File Change Detected On : " + path);
-
-      if (requiredFileChanged) {
-        if (settings.autoUpload) {
-          if (
-            customSettings.ignoreUploadFolders.indexOf("workspaceStorage") > -1
-          ) {
-            const fileType: string = path.substring(
-              path.lastIndexOf("."),
-              path.length
-            );
-            if (fileType.indexOf("json") === -1) {
-              console.log(
-                "Sync : Cannot Initiate Auto-upload on This File (Not JSON)."
-              );
-              uploadStopped = true;
-              return;
-            }
-          }
-
-          console.log("Sync : Initiating Auto-upload For File : " + path);
-          this.InitiateAutoUpload(path)
-            .then(isDone => {
-              uploadStopped = isDone;
-              return lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-            })
-            .catch(() => {
-              uploadStopped = true;
-              return lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-            });
-        }
-      } else {
-        uploadStopped = true;
-        await lockfile.Unlock(this.en.FILE_SYNC_LOCK);
-      }
+    this.autoUploadService = new AutoUploadService({
+      en: this.en,
+      commons: this,
+      ignored
     });
-  }
-
-  public async InitiateAutoUpload(path: string): Promise<boolean> {
-    vscode.window.setStatusBarMessage("").dispose();
-    vscode.window.setStatusBarMessage(
-      localize("common.info.initAutoUpload"),
-      5000
-    );
-
-    await Util.Sleep(3000);
-
-    vscode.commands.executeCommand(
-      "extension.updateSettings",
-      "forceUpdate",
-      path
-    );
-
-    return true;
-  }
-
-  public CloseWatch(): void {
-    if (Commons.configWatcher != null) {
-      Commons.configWatcher.dispose();
-    }
-    if (Commons.extensionWatcher != null) {
-      Commons.extensionWatcher.dispose();
-    }
   }
 
   public async InitalizeSettings(

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -148,13 +148,8 @@ export default class Commons {
         const customSettingStr: string = await FileService.ReadFile(
           this.en.FILE_CUSTOMIZEDSETTINGS
         );
-        const tempObj: {
-          [key: string]: any;
-          ignoreUploadSettings: string[];
-        } = JSON.parse(customSettingStr);
-        if (!Array.isArray(tempObj.ignoreUploadSettings)) {
-          tempObj.ignoreUploadSettings = [];
-        }
+        const tempObj = JSON.parse(customSettingStr);
+
         Object.assign(customSettings, tempObj);
         customSettings.token = customSettings.token.trim();
         return customSettings;
@@ -180,13 +175,9 @@ export default class Commons {
 
   public async SetCustomSettings(setting: CustomSettings): Promise<boolean> {
     try {
-      const json: { [key: string]: any; ignoreUploadSettings: string[] } = {
-        ...setting
-      };
-      delete json.ignoreUploadSettings;
       await FileService.WriteFile(
         this.en.FILE_CUSTOMIZEDSETTINGS,
-        JSON.stringify(json, null, 4)
+        JSON.stringify(setting, null, 4)
       );
       return true;
     } catch (e) {
@@ -234,6 +225,14 @@ export default class Commons {
         });
     } else if (customSettings.version < Environment.CURRENT_VERSION) {
       fileChanged = true;
+      // #TODO : Remove this in new update
+      const newIgnoredList = new CustomSettings().ignoreUploadFiles;
+      newIgnoredList.forEach(m => {
+        if (customSettings.ignoreUploadFiles.indexOf(m) === -1) {
+          customSettings.ignoreUploadFiles.push(m);
+        }
+      });
+
       if (this.context.globalState.get("synctoken")) {
         const token = this.context.globalState.get("synctoken");
         if (token !== "") {

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -17,7 +17,7 @@ export function osTypeFromString(osName: string): OsType {
 }
 
 export class Environment {
-  public static CURRENT_VERSION: number = 327;
+  public static CURRENT_VERSION: number = 328;
   public static getVersion(): string {
     return (
       Environment.CURRENT_VERSION.toString().slice(0, 1) +

--- a/src/pragmaUtil.ts
+++ b/src/pragmaUtil.ts
@@ -116,12 +116,12 @@ export default class PragmaUtil {
    * Remove @sync-ignore settings before upload.
    *
    * @static
-   * @param {string} settingsContent
+   * @param {string} fileContent
    * @returns {string}
    * @memberof PragmaUtil
    */
-  public static processBeforeUpload(settingsContent: string): string {
-    const lines = settingsContent.split("\n");
+  public static processBeforeUpload(fileContent: string): string {
+    const lines = fileContent.split("\n");
     let osMatch: RegExpMatchArray;
     let osFromPragma: string;
 
@@ -256,7 +256,7 @@ export default class PragmaUtil {
       parsedLines.push(this.toggleComments(currentLine, shouldComment));
     }
 
-    const opensCurlyBraces = /".+"\s*:\s*{/.test(currentLine);
+    const opensCurlyBraces = /{/.test(currentLine);
     const opensBrackets = /".+"\s*:\s*\[/.test(currentLine);
 
     let openedBlock = opensCurlyBraces || opensBrackets;

--- a/src/service/autoUploadService.ts
+++ b/src/service/autoUploadService.ts
@@ -1,0 +1,94 @@
+import { watch } from "chokidar";
+import * as vscode from "vscode";
+import Commons from "../commons";
+import { Environment } from "../environmentPath";
+import localize from "../localize";
+import lockfile from "../lockfile";
+import { CustomSettings } from "../setting";
+import { Util } from "../util";
+import { FileService } from "./fileService";
+
+export class AutoUploadService {
+  public static GetIgnoredItems(customSettings: CustomSettings) {
+    return [
+      ...customSettings.ignoreUploadFolders.map(folder => `**/${folder}/**`),
+      ...customSettings.ignoreUploadFiles.map(file => `**/${file}`)
+    ];
+  }
+
+  public watching = false;
+
+  private watcher = watch(this.options.en.USER_FOLDER, {
+    depth: 2,
+    ignored: this.options.ignored
+  });
+
+  constructor(
+    private options: { en: Environment; commons: Commons; ignored: string[] }
+  ) {
+    vscode.extensions.onDidChange(async () => {
+      if (this.watching) {
+        console.log("Sync: Extensions changed");
+        if (await lockfile.Check(this.options.en.FILE_SYNC_LOCK)) {
+          return;
+        } else {
+          await lockfile.Lock(this.options.en.FILE_SYNC_LOCK);
+        }
+        const customSettings: CustomSettings = await this.options.commons.GetCustomSettings();
+        if (customSettings) {
+          await this.InitiateAutoUpload();
+        }
+        await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
+        return;
+      }
+    });
+  }
+
+  public async StartWatching() {
+    this.StopWatching();
+
+    this.watching = true;
+
+    this.watcher.addListener("change", async (path: string) => {
+      if (this.watching) {
+        console.log(`Sync: ${FileService.ExtractFileName(path)} changed`);
+        if (await lockfile.Check(this.options.en.FILE_SYNC_LOCK)) {
+          return;
+        } else {
+          await lockfile.Lock(this.options.en.FILE_SYNC_LOCK);
+        }
+
+        const customSettings: CustomSettings = await this.options.commons.GetCustomSettings();
+        if (customSettings) {
+          const fileType: string = path
+            .substring(path.lastIndexOf("."), path.length)
+            .slice(1);
+          if (customSettings.supportedFileExtensions.indexOf(fileType) !== -1) {
+            await this.InitiateAutoUpload();
+          }
+        }
+        await lockfile.Unlock(this.options.en.FILE_SYNC_LOCK);
+        return;
+      }
+    });
+  }
+
+  public StopWatching() {
+    if (this.watcher) {
+      this.watcher.removeAllListeners();
+    }
+    this.watching = false;
+  }
+
+  private async InitiateAutoUpload() {
+    vscode.window.setStatusBarMessage("").dispose();
+    vscode.window.setStatusBarMessage(
+      localize("common.info.initAutoUpload"),
+      5000
+    );
+
+    await Util.Sleep(5000);
+
+    vscode.commands.executeCommand("extension.updateSettings", "forceUpdate");
+  }
+}

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -155,8 +155,6 @@ export class PluginService {
     const list: ExtensionInformation[] = [];
 
     for (const ext of vscode.extensions.all) {
-      console.log(ext.extensionPath);
-
       if (ext.packageJSON.isBuiltin === true) {
         continue;
       }

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -4,10 +4,6 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { OsType } from "../enums";
-import * as util from "../util";
-
-const apiPath =
-  "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery";
 
 export class ExtensionInformation {
   public static fromJSON(text: string) {

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -237,14 +237,11 @@ export class PluginService {
 
   public static async InstallExtensions(
     extensions: string,
-    extFolder: string,
-    useCli: boolean,
     ignoredExtensions: string[],
     osType: OsType,
     insiders: boolean,
     notificationCallBack: (...data: any[]) => void
   ): Promise<ExtensionInformation[]> {
-    let actionList: Array<Promise<void>> = [];
     let addedExtensions: ExtensionInformation[] = [];
     const missingList = PluginService.GetMissingExtensions(
       extensions,
@@ -254,29 +251,13 @@ export class PluginService {
       notificationCallBack("Sync : No Extensions needs to be installed.");
       return [];
     }
-
-    if (useCli) {
-      addedExtensions = await PluginService.ProcessInstallationCLI(
-        missingList,
-        osType,
-        insiders,
-        notificationCallBack
-      );
-      return addedExtensions;
-    } else {
-      actionList = await this.ProcessInstallation(
-        extFolder,
-        notificationCallBack,
-        missingList
-      );
-      try {
-        await Promise.all(actionList);
-        return addedExtensions;
-      } catch (err) {
-        // always return extension list
-        return addedExtensions;
-      }
-    }
+    addedExtensions = await PluginService.ProcessInstallationCLI(
+      missingList,
+      osType,
+      insiders,
+      notificationCallBack
+    );
+    return addedExtensions;
   }
 
   public static async ProcessInstallationCLI(
@@ -355,184 +336,5 @@ export class PluginService {
     }
 
     return addedExtensions;
-  }
-
-  public static async ProcessInstallation(
-    extFolder: string,
-    notificationCallBack: (...data: any[]) => void,
-    missingList: ExtensionInformation[]
-  ) {
-    const actionList: Array<Promise<void>> = [];
-    const addedExtensions: ExtensionInformation[] = [];
-    let totalInstalled: number = 0;
-    for (const element of missingList) {
-      actionList.push(
-        PluginService.InstallExtension(element, extFolder).then(
-          () => {
-            totalInstalled = totalInstalled + 1;
-            notificationCallBack(
-              "Sync : Extension " +
-                totalInstalled +
-                " of " +
-                missingList.length.toString() +
-                " installed.",
-              false
-            );
-            addedExtensions.push(element);
-          },
-          (err: any) => {
-            console.error(err);
-            notificationCallBack(
-              "Sync : " + element.name + " Download Failed.",
-              true
-            );
-          }
-        )
-      );
-    }
-    return actionList;
-  }
-
-  public static async InstallExtension(
-    item: ExtensionInformation,
-    ExtensionFolder: string
-  ) {
-    const header = {
-      Accept: "application/json;api-version=3.0-preview.1"
-    };
-    let extractPath: string = null;
-
-    const data = {
-      filters: [
-        {
-          criteria: [
-            {
-              filterType: 4,
-              value: item.metadata.id
-            }
-          ]
-        }
-      ],
-      flags: 133
-    };
-
-    try {
-      const res = await util.Util.HttpPostJson(apiPath, data, header);
-      let downloadUrl: string;
-
-      try {
-        let targetVersion = null;
-        const content = JSON.parse(res);
-
-        // Find correct version
-        for (const result of content.results) {
-          for (const extension of result.extensions) {
-            for (const version of extension.versions) {
-              if (version.version === item.version) {
-                targetVersion = version;
-                break;
-              }
-            }
-            if (targetVersion !== null) {
-              break;
-            }
-          }
-          if (targetVersion !== null) {
-            break;
-          }
-        }
-
-        if (
-          targetVersion === null ||
-          !targetVersion ||
-          !targetVersion.assetUri
-        ) {
-          // unable to find one
-          throw new Error("NA");
-        }
-
-        // Proceed to install
-        downloadUrl =
-          targetVersion.assetUri +
-          "/Microsoft.VisualStudio.Services.VSIXPackage?install=true";
-        console.log("Installing from Url :" + downloadUrl);
-      } catch (error) {
-        if (error === "NA" || error.message === "NA") {
-          console.error(
-            "Sync : Extension : '" +
-              item.name +
-              "' - Version : '" +
-              item.version +
-              "' Not Found in marketplace. Remove the extension and upload the settings to fix this."
-          );
-        }
-        console.error(error);
-        throw error;
-      }
-
-      const filePath = await util.Util.HttpGetFile(downloadUrl);
-
-      const dir = await util.Util.Extract(filePath);
-
-      extractPath = dir;
-      const packageJson = await PluginService.GetPackageJson(dir, item);
-
-      Object.assign(packageJson, {
-        __metadata: item.metadata
-      });
-
-      const text = JSON.stringify(packageJson, null, " ");
-      await PluginService.WritePackageJson(extractPath, text);
-
-      // Move the folder to correct path
-      const destination = path.join(
-        ExtensionFolder,
-        item.publisher + "." + item.name + "-" + item.version
-      );
-      const source = path.join(extractPath, "extension");
-      await PluginService.CopyExtension(destination, source);
-    } catch (err) {
-      console.error(
-        `Sync : Extension : '${item.name}' - Version : '${item.version}'` + err
-      );
-      throw err;
-    }
-  }
-
-  private static async CopyExtension(
-    destination: string,
-    source: string
-  ): Promise<void> {
-    await fs.copy(source, destination, { overwrite: true });
-  }
-  private static async WritePackageJson(dirName: string, packageJson: string) {
-    await fs.writeFile(
-      dirName + "/extension/package.json",
-      packageJson,
-      "utf-8"
-    );
-  }
-  private static async GetPackageJson(
-    dirName: string,
-    item: ExtensionInformation
-  ) {
-    const text = await fs.readFile(
-      dirName + "/extension/package.json",
-      "utf-8"
-    );
-
-    const config = JSON.parse(text);
-
-    if (config.name !== item.name) {
-      throw new Error("name not equal");
-    }
-    if (config.publisher !== item.publisher) {
-      throw new Error("publisher not equal");
-    }
-    if (config.version !== item.version) {
-      throw new Error("version not equal");
-    }
-
-    return config;
   }
 }

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -30,6 +30,11 @@ export class KeyValue<T, S> {
 
 export class CustomSettings {
   public ignoreUploadFiles: string[] = [
+    "state.vscdb",
+    "state.vscdb.backup",
+    "syncLocalSettings.json",
+    ".DS_Store",
+    "sync.lock",
     "projects.json",
     "projects_cache_vscode.json",
     "projects_cache_git.json",

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -44,7 +44,6 @@ export class CustomSettings {
   ];
   public ignoreUploadFolders: string[] = ["workspaceStorage"];
   public ignoreExtensions: string[] = [];
-  public ignoreUploadSettings: string[] = [];
   public gistDescription: string = "Visual Studio Code Settings Sync Gist";
   public version: number = Environment.CURRENT_VERSION;
   public token: string = "";

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -45,7 +45,6 @@ export class CustomSettings {
   public ignoreUploadFolders: string[] = ["workspaceStorage"];
   public ignoreExtensions: string[] = [];
   public ignoreUploadSettings: string[] = [];
-  public replaceCodeSettings: { [key: string]: any } = {};
   public gistDescription: string = "Visual Studio Code Settings Sync Gist";
   public version: number = Environment.CURRENT_VERSION;
   public token: string = "";

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -667,17 +667,6 @@ export class Sync {
             5000
           );
         }
-        if (Object.keys(customSettings.replaceCodeSettings).length > 0) {
-          const config = vscode.workspace.getConfiguration();
-          const keysDefined: string[] = Object.keys(
-            customSettings.replaceCodeSettings
-          );
-          for (const key of keysDefined) {
-            const value: string = customSettings.replaceCodeSettings[key];
-            const c: any = value === "" ? undefined : value;
-            config.update(key, c, true);
-          }
-        }
         if (syncSetting.autoUpload) {
           globalCommonService.autoUploadService.StartWatching();
         }
@@ -775,7 +764,6 @@ export class Sync {
       "cmd.otherOptions.toggleAutoUpload",
       "cmd.otherOptions.toggleAutoDownload",
       "cmd.otherOptions.toggleSummaryPage",
-      "cmd.otherOptions.preserve",
       "cmd.otherOptions.customizedSync",
       "cmd.otherOptions.downloadCustomFile",
       "cmd.otherOptions.joinCommunity",
@@ -868,34 +856,6 @@ export class Sync {
         setting.quietSync = !setting.quietSync;
       },
       7: async () => {
-        // preserve
-        const options: vscode.InputBoxOptions = {
-          ignoreFocusOut: true,
-          placeHolder: localize("cmd.otherOptions.preserve.placeholder"),
-          prompt: localize("cmd.otherOptions.preserve.prompt")
-        };
-        const input = await vscode.window.showInputBox(options);
-
-        if (input) {
-          const settingKey: string = input;
-          const a = vscode.workspace.getConfiguration();
-          const val: string = a.get<string>(settingKey);
-          customSettings.replaceCodeSettings[input] = val;
-          const done: boolean = await common.SetCustomSettings(customSettings);
-          if (done) {
-            if (val === "") {
-              vscode.window.showInformationMessage(
-                localize("cmd.otherOptions.preserve.info.done1", input)
-              );
-            } else {
-              vscode.window.showInformationMessage(
-                localize("cmd.otherOptions.preserve.info.done2", input, val)
-              );
-            }
-          }
-        }
-      },
-      8: async () => {
         // add customized sync file
         const options: vscode.InputBoxOptions = {
           ignoreFocusOut: true,
@@ -918,7 +878,7 @@ export class Sync {
           }
         }
       },
-      9: async () => {
+      8: async () => {
         // Import customized sync file to workspace
         const customFiles = await this.getCustomFilesFromGist(
           customSettings,
@@ -962,7 +922,7 @@ export class Sync {
           }
         }
       },
-      10: async () => {
+      9: async () => {
         vscode.commands.executeCommand(
           "vscode.open",
           vscode.Uri.parse(
@@ -970,7 +930,7 @@ export class Sync {
           )
         );
       },
-      11: async () => {
+      10: async () => {
         vscode.commands.executeCommand(
           "vscode.open",
           vscode.Uri.parse(
@@ -978,7 +938,7 @@ export class Sync {
           )
         );
       },
-      12: async () => {
+      11: async () => {
         vscode.commands.executeCommand(
           "vscode.open",
           vscode.Uri.parse(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -74,6 +74,7 @@ export class Sync {
    * Upload setting to github gist
    */
   public async upload(): Promise<void> {
+    // @ts-ignore
     const args = arguments;
     const env = new Environment(this.context);
     let github: GitHubService = null;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -184,10 +184,10 @@ export class Sync {
           contentFiles = contentFiles.filter((contentFile: File) => {
             const matchedFolders = customSettings.ignoreUploadFolders.filter(
               folder => {
-                return contentFile.filePath.indexOf(folder) === -1;
+                return contentFile.filePath.indexOf(folder) !== -1;
               }
             );
-            return matchedFolders.length > 0;
+            return matchedFolders.length === 0;
           });
         }
         const customFileKeys: string[] = Object.keys(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -97,9 +97,7 @@ export class Sync {
         localConfig.customConfig.token,
         localConfig.customConfig.githubEnterpriseUrl
       );
-      // ignoreSettings = await common.GetIgnoredSettings(localConfig.customConfig.ignoreUploadSettings);
       await startGitProcess(localConfig.extConfig, localConfig.customConfig);
-      // await common.SetIgnoredSettings(ignoreSettings);
     } catch (error) {
       Commons.LogException(error, globalCommonService.ERROR_MESSAGE, true);
       return;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -227,7 +227,11 @@ export class Sync {
           }
         }
 
-        if (snippetFile.fileName === env.FILE_SETTING_NAME) {
+        if (
+          snippetFile.fileName === env.FILE_SETTING_NAME ||
+          snippetFile.fileName === env.FILE_KEYBINDING_MAC ||
+          snippetFile.fileName === env.FILE_KEYBINDING_DEFAULT
+        ) {
           try {
             snippetFile.content = PragmaUtil.processBeforeUpload(
               snippetFile.content
@@ -602,7 +606,11 @@ export class Sync {
                 );
               }
 
-              if (file.gistName === env.FILE_SETTING_NAME) {
+              if (
+                file.gistName === env.FILE_SETTING_NAME ||
+                file.gistName !== env.FILE_KEYBINDING_MAC ||
+                file.gistName === env.FILE_KEYBINDING_DEFAULT
+              ) {
                 const localContent = await FileService.ReadFile(filePath);
                 content = PragmaUtil.processBeforeWrite(
                   localContent,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -554,8 +554,6 @@ export class Sync {
 
                 addedExtensions = await PluginService.InstallExtensions(
                   content,
-                  env.ExtensionFolder,
-                  useCli,
                   ignoredExtensions,
                   env.OsType,
                   env.isInsiders,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,13 +1,11 @@
 "use strict";
 
-import * as adm_zip from "adm-zip";
 import * as fs from "fs-extra";
 import * as http from "http";
 import * as https from "https";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import * as _temp from "temp";
 import * as url from "url";
-import { promisify } from "util";
 import * as vscode from "vscode";
 
 interface IHeaders {
@@ -139,13 +137,6 @@ export class Util {
     const tempFile: string = temp.path();
     await fs.writeFile(tempFile, content);
     return tempFile;
-  }
-
-  public static async Extract(filePath: string) {
-    const zip = new adm_zip(filePath);
-    const dirName = await promisify(temp.mkdir)(undefined);
-    zip.extractAllTo(dirName, /*overwrite*/ true);
-    return dirName;
   }
 
   public static async Sleep(ms: number): Promise<number> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "outDir": "out",
-    "lib": ["es2015","es2016","es2017", "es2018", "esnext"],
+    "lib": ["es2015", "es2016", "es2017", "es2018", "esnext"],
     "sourceMap": true,
     "rootDir": ".",
     "noUnusedLocals": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,8 @@
-
 "use strict";
 
 const path = require("path");
-const CleanWebpackPlugin = require("clean-webpack-plugin");
-
+const CleanWebpackPlugin = require("clean-webpack-plugin").default;
+const webpack = require("webpack");
 
 /** @type WebpackOptions */
 const config = {
@@ -36,8 +35,10 @@ const config = {
     fsevents: "commonjs fsevents",
     "original-fs": "commonjs original-fs"
   },
-  devtool: "source-map",
-  plugins: [new CleanWebpackPlugin()]
+  plugins: [new CleanWebpackPlugin()],
+  optimization: {
+    minimize: true
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
#### Utilized pragmaUtil Functions (`processBeforeUpload` / `processBeforeWrite`) for `keybindings.json` file as well


#### Changes proposed in this pull request:

- Regx for `opensCurlyBraces` is changed
- Variable name are made more generic
- Same functions are used for `keybindings.json` which were used for `settings.json`

**Fixes**: #800 #515 

#### How Has This Been Tested?
- Manually used for syncing my settings.
- Testing using `Launch Tests` was failing before any new changes. We need to fix them.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [x] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
