### PR TITLE
docs: make generating token more user-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,7 @@ All extensions and complete User Folder that Contains
 
 This extension requires a Personal Access Token from your GitHub account. You can create one by simply following the steps shown in the pictures below. Make sure you add **Gist** in scope.
 
-**Go to [Settings](https://github.com/settings) / [Developer settings](https://github.com/settings/tokens) / [Personal access tokens](https://github.com/settings/tokens) / Generate New Token**
-
-
-![Goto Settings / Developer settings / Personal Access Tokens](https://shanalikhan.github.io/img/github1.PNG)
-
-**Select Gist From Scopes.**
+**[Generate New Token](https://github.com/settings/tokens/new?description=code-setting-sync&scopes=gist)**
 
 ![Select Scopes](https://shanalikhan.github.io/img/github2.PNG)
 


### PR DESCRIPTION
#### Short description of what this resolves:

use URL query string to automatically select gist and add a description
now can generate the token just by one click

#### Changes proposed in this pull request:

- just let lazy people like me make fewer efforts
- maybe you should change the photo of README

**Fixes**: # None

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
only docs changed

#### Screenshots (if appropriate):


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [x] I have updated the documentation and Wiki accordingly.
