### PR TITLE
Utilized pragmaUtil Functions for kb.json file

### DIFF
--- a/src/pragmaUtil.ts
+++ b/src/pragmaUtil.ts
@@ -118,12 +118,12 @@ export default class PragmaUtil {
    * Remove @sync-ignore settings before upload.
    *
    * @static
-   * @param {string} settingsContent
+   * @param {string} fileContent
    * @returns {string}
    * @memberof PragmaUtil
    */
-  public static processBeforeUpload(settingsContent: string): string {
-    const lines = settingsContent.split("\n");
+  public static processBeforeUpload(fileContent: string): string {
+    const lines = fileContent.split("\n");
     let osMatch: RegExpMatchArray;
     let osFromPragma: string;
 
@@ -258,7 +258,7 @@ export default class PragmaUtil {
       parsedLines.push(this.toggleComments(currentLine, shouldComment));
     }
 
-    const opensCurlyBraces = /".+"\s*:\s*{/.test(currentLine);
+    const opensCurlyBraces = /{/.test(currentLine);
     const opensBrackets = /".+"\s*:\s*\[/.test(currentLine);
 
     let openedBlock = opensCurlyBraces || opensBrackets;

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -57,4 +57,5 @@ export class CustomSettings {
   public askGistName: boolean = false;
   public customFiles: { [key: string]: string } = {};
   public hostName: string = null;
+  public universalKeybindings: boolean = false;
 }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -221,7 +221,8 @@ export class Sync {
           if (snippetFile.content !== "") {
             if (snippetFile.fileName === env.FILE_KEYBINDING_NAME) {
               snippetFile.gistName =
-                env.OsType === OsType.Mac
+                env.OsType === OsType.Mac &&
+                !customSettings.universalKeybindings
                   ? env.FILE_KEYBINDING_MAC
                   : env.FILE_KEYBINDING_DEFAULT;
             }
@@ -489,17 +490,23 @@ export class Sync {
               );
               updatedFiles.push(f);
             } else if (gistName.indexOf(".") > -1) {
-              if (
-                env.OsType === OsType.Mac &&
-                gistName === env.FILE_KEYBINDING_DEFAULT
-              ) {
-                return;
-              }
-              if (
-                env.OsType !== OsType.Mac &&
-                gistName === env.FILE_KEYBINDING_MAC
-              ) {
-                return;
+              if (customSettings.universalKeybindings) {
+                if (gistName === env.FILE_KEYBINDING_MAC) {
+                  return;
+                }
+              } else {
+                if (
+                  env.OsType === OsType.Mac &&
+                  gistName === env.FILE_KEYBINDING_DEFAULT
+                ) {
+                  return;
+                }
+                if (
+                  env.OsType !== OsType.Mac &&
+                  gistName === env.FILE_KEYBINDING_MAC
+                ) {
+                  return;
+                }
               }
               const f: File = new File(
                 gistName,
@@ -587,7 +594,7 @@ export class Sync {
               file.gistName === env.FILE_KEYBINDING_MAC
             ) {
               let test: string = "";
-              env.OsType === OsType.Mac
+              env.OsType === OsType.Mac && !customSettings.universalKeybindings
                 ? (test = env.FILE_KEYBINDING_MAC)
                 : (test = env.FILE_KEYBINDING_DEFAULT);
               if (file.gistName !== test) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -229,7 +229,11 @@ export class Sync {
           }
         }
 
-        if (snippetFile.fileName === env.FILE_SETTING_NAME) {
+        if (
+          snippetFile.fileName === env.FILE_SETTING_NAME ||
+          snippetFile.fileName === env.FILE_KEYBINDING_MAC ||
+          snippetFile.fileName === env.FILE_KEYBINDING_DEFAULT
+        ) {
           try {
             snippetFile.content = PragmaUtil.processBeforeUpload(
               snippetFile.content
@@ -604,7 +608,11 @@ export class Sync {
                 );
               }
 
-              if (file.gistName === env.FILE_SETTING_NAME) {
+              if (
+                file.gistName === env.FILE_SETTING_NAME ||
+                file.gistName !== env.FILE_KEYBINDING_MAC ||
+                file.gistName === env.FILE_KEYBINDING_DEFAULT
+              ) {
                 const localContent = await FileService.ReadFile(filePath);
                 content = PragmaUtil.processBeforeWrite(
                   localContent,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -610,7 +610,7 @@ export class Sync {
 
               if (
                 file.gistName === env.FILE_SETTING_NAME ||
-                file.gistName !== env.FILE_KEYBINDING_MAC ||
+                file.gistName === env.FILE_KEYBINDING_MAC ||
                 file.gistName === env.FILE_KEYBINDING_DEFAULT
               ) {
                 const localContent = await FileService.ReadFile(filePath);


### PR DESCRIPTION
#### Utilized pragmaUtil Functions (`processBeforeUpload` / `processBeforeWrite`) for `keybindings.json` file as well


#### Changes proposed in this pull request:

- Regx for `opensCurlyBraces` is changed
- Variable name are made more generic
- Same functions are used for `keybindings.json` which were used for `settings.json`

**Fixes**: #800 #515 

#### How Has This Been Tested?
- Manually used for syncing my settings.
- Testing using `Launch Tests` was failing before any new changes. We need to fix them.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [x] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
