### PR TITLE
[Done] Improve compatibility with different versions of VSCode

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,7 +1,7 @@
 export enum OsType {
-  Windows = 1,
-  Linux,
-  Mac
+  Windows = "windows",
+  Linux = "linux",
+  Mac = "darwin"
 }
 
 export enum SettingType {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,5 +1,5 @@
 export enum OsType {
-  Windows = "windows",
+  Windows = "win32",
   Linux = "linux",
   Mac = "darwin"
 }

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as path from "path";
+import { resolve } from "path";
 import * as vscode from "vscode";
 import { OsType } from "./enums";
 
@@ -70,24 +70,23 @@ export class Environment {
     this.isPortable = !!process.env.VSCODE_PORTABLE;
 
     if (!this.isPortable) {
-      this.PATH = path
-        .resolve(this.context.globalStoragePath, "../../..")
-        .concat("/");
-      this.USER_FOLDER = path.resolve(this.PATH, "User").concat("/");
-      this.EXTENSION_FOLDER = path
-        .resolve(vscode.extensions.all[72].extensionPath, "..")
-        .concat("/"); // 0-71 are vscode built-in extensions that are in a separate folder. 72 is the first user-installed extension
-      this.CODE_BIN = path
-        .basename(path.resolve(this.EXTENSION_FOLDER, ".."))
-        .slice(3);
+      this.PATH = resolve(this.context.globalStoragePath, "../../..").concat(
+        "/"
+      );
+      this.USER_FOLDER = resolve(this.PATH, "User").concat("/");
+      this.EXTENSION_FOLDER = resolve(
+        vscode.extensions.all[72].extensionPath,
+        ".."
+      ).concat("/"); // 0-71 are vscode built-in extensions that are in a separate folder. 72 is the first user-installed extension
     }
 
     if (this.isPortable) {
       this.PATH = process.env.VSCODE_PORTABLE;
-      this.USER_FOLDER = path.resolve(this.PATH, "user-data/User").concat("/");
-      this.EXTENSION_FOLDER = path.resolve(this.PATH, "extensions").concat("/");
-      this.CODE_BIN = "./bin/code*";
+      this.USER_FOLDER = resolve(this.PATH, "user-data/User").concat("/");
+      this.EXTENSION_FOLDER = resolve(this.PATH, "extensions").concat("/");
     }
+
+    this.CODE_BIN = process.argv0;
 
     this.OsType = process.platform as OsType;
 

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -86,7 +86,7 @@ export class Environment {
       this.EXTENSION_FOLDER = resolve(this.PATH, "extensions").concat("/");
     }
 
-    this.CODE_BIN = process.argv0;
+    this.CODE_BIN = `"${process.argv0}"`; // process.argv0 returns the code executable path
 
     this.OsType = process.platform as OsType;
 

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -26,6 +26,10 @@ export class Environment {
     );
   }
 
+  // public isInsiders: boolean = false;
+  // public isOss: boolean = false;
+  // public isCoderCom: boolean = false;
+
   public isPortable: boolean = false;
   public homeDir: string | null = null;
   public USER_FOLDER: string = null;
@@ -80,6 +84,93 @@ export class Environment {
     }
 
     this.OsType = process.platform as OsType;
+
+    /* Start Legacy Code
+
+    this.isInsiders = /insiders/.test(this.context.asAbsolutePath(""));
+    this.isOss = /\boss\b/.test(this.context.asAbsolutePath(""));
+    this.isCoderCom =
+      vscode.extensions.getExtension("coder.coder") !== undefined;
+    const isXdg =
+      !this.isInsiders &&
+      !this.isCoderCom &&
+      process.platform === "linux" &&
+      !!process.env.XDG_DATA_HOME;
+    this.homeDir = isXdg
+      ? process.env.XDG_DATA_HOME
+      : process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"];
+    const configSuffix = `${isXdg || this.isCoderCom ? "" : "."}vscode${
+      this.isInsiders ? "-insiders" : this.isOss ? "-oss" : ""
+    }`;
+
+    if (!this.isPortable) {
+      if (process.platform === "darwin") {
+        this.PATH = process.env.HOME + "/Library/Application Support";
+        this.OsType = OsType.Mac;
+      } else if (process.platform === "linux") {
+        if (!this.isCoderCom) {
+          this.PATH =
+            isXdg && !!process.env.XDG_CONFIG_HOME
+              ? process.env.XDG_CONFIG_HOME
+              : os.homedir() + "/.config";
+        } else {
+          this.PATH = "/tmp";
+        }
+        this.OsType = OsType.Linux;
+      } else if (process.platform === "win32") {
+        this.PATH = process.env.APPDATA;
+        this.OsType = OsType.Windows;
+      } else {
+        this.PATH = "/var/local";
+        this.OsType = OsType.Linux;
+      }
+    }
+
+    if (this.isPortable) {
+      this.PATH = process.env.VSCODE_PORTABLE;
+      if (process.platform === "darwin") {
+        this.OsType = OsType.Mac;
+      } else if (process.platform === "linux") {
+        this.OsType = OsType.Linux;
+      } else if (process.platform === "win32") {
+        this.OsType = OsType.Windows;
+      } else {
+        this.OsType = OsType.Linux;
+      }
+    }
+
+    if (!this.isPortable) {
+      const possibleCodePaths = [];
+      if (this.isInsiders) {
+        possibleCodePaths.push("/Code - Insiders");
+      } else if (this.isOss) {
+        possibleCodePaths.push("/Code - OSS");
+        possibleCodePaths.push("/VSCodium");
+      } else {
+        possibleCodePaths.push("/Code");
+      }
+      for (const possibleCodePath of possibleCodePaths) {
+        try {
+          fs.statSync(this.PATH + possibleCodePath);
+          this.PATH = this.PATH + possibleCodePath;
+          break;
+        } catch (e) {
+          console.error("Error :" + possibleCodePath);
+          console.error(e);
+        }
+      }
+      this.ExtensionFolder = path.join(
+        this.homeDir,
+        configSuffix,
+        "extensions"
+      );
+      this.USER_FOLDER = this.PATH.concat("/User/");
+    } else {
+      this.USER_FOLDER = this.PATH.concat("/user-data/User/");
+      this.ExtensionFolder = this.PATH.concat("/extensions/");
+    }
+
+    End Legacy Code */
 
     this.FILE_EXTENSION = this.USER_FOLDER.concat(this.FILE_EXTENSION_NAME);
     this.FILE_SETTING = this.USER_FOLDER.concat(this.FILE_SETTING_NAME);

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { resolve } from "path";
+import { basename, resolve } from "path";
 import * as vscode from "vscode";
 import { OsType } from "./enums";
 
@@ -78,15 +78,20 @@ export class Environment {
         vscode.extensions.all[72].extensionPath,
         ".."
       ).concat("/"); // 0-71 are vscode built-in extensions that are in a separate folder. 72 is the first user-installed extension
+      this.CODE_BIN = `"${process.argv0}"`;
     }
 
     if (this.isPortable) {
       this.PATH = process.env.VSCODE_PORTABLE;
       this.USER_FOLDER = resolve(this.PATH, "user-data/User").concat("/");
       this.EXTENSION_FOLDER = resolve(this.PATH, "extensions").concat("/");
+      this.CODE_BIN = `"${resolve(
+        this.PATH,
+        "..",
+        "bin",
+        basename(process.argv0)
+      )}"`;
     }
-
-    this.CODE_BIN = `"${process.argv0}"`; // process.argv0 returns the code executable path
 
     this.OsType = process.platform as OsType;
 

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -29,10 +29,12 @@ export class Environment {
   // public isInsiders: boolean = false;
   // public isOss: boolean = false;
   // public isCoderCom: boolean = false;
+  // public homeDir: string | null = null;
 
   public isPortable: boolean = false;
-  public homeDir: string | null = null;
   public USER_FOLDER: string = null;
+
+  public CODE_BIN: string;
 
   public EXTENSION_FOLDER: string = null;
   public PATH: string = null;
@@ -75,12 +77,16 @@ export class Environment {
       this.EXTENSION_FOLDER = path
         .resolve(vscode.extensions.all[72].extensionPath, "..")
         .concat("/"); // 0-71 are vscode built-in extensions that are in a separate folder. 72 is the first user-installed extension
+      this.CODE_BIN = path
+        .basename(path.resolve(this.EXTENSION_FOLDER, ".."))
+        .slice(3);
     }
 
     if (this.isPortable) {
       this.PATH = process.env.VSCODE_PORTABLE;
       this.USER_FOLDER = path.resolve(this.PATH, "user-data/User").concat("/");
       this.EXTENSION_FOLDER = path.resolve(this.PATH, "extensions").concat("/");
+      this.CODE_BIN = "./bin/code*";
     }
 
     this.OsType = process.platform as OsType;
@@ -99,8 +105,8 @@ export class Environment {
     this.homeDir = isXdg
       ? process.env.XDG_DATA_HOME
       : process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"];
-    const configSuffix = `${isXdg || this.isCoderCom ? "" : "."}vscode${
-      this.isInsiders ? "-insiders" : this.isOss ? "-oss" : ""
+    const configSuffix = `; $; {isXdg || this.isCoderCom ? "" : "."; }vscode$; {
+      this.isInsiders ? "-insiders" : this.isOss ? "-oss" : "";
     }`;
 
     if (!this.isPortable) {

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -1,7 +1,6 @@
 "use strict";
 
-import { existsSync } from "fs";
-import { basename, resolve } from "path";
+import { resolve } from "path";
 import * as vscode from "vscode";
 import { OsType } from "./enums";
 
@@ -82,26 +81,12 @@ export class Environment {
         )[0].extensionPath,
         ".."
       ).concat("/"); // Gets first non-builtin extension's path
-      if (this.OsType === OsType.Windows) {
-        this.CODE_BIN = `for /r "bin" %a in (*.cmd) do "%~fa"`;
-      } else {
-        if (existsSync("./bin")) {
-          this.CODE_BIN = "./bin/*";
-        } else {
-          this.CODE_BIN = `"/bin/${basename(vscode.env.appRoot)}"`;
-        }
-      }
     }
 
     if (this.isPortable) {
       this.PATH = process.env.VSCODE_PORTABLE;
       this.USER_FOLDER = resolve(this.PATH, "user-data/User").concat("/");
       this.EXTENSION_FOLDER = resolve(this.PATH, "extensions").concat("/");
-      if (this.OsType === OsType.Windows) {
-        this.CODE_BIN = `for /r "bin" %a in (*.cmd) do "%~fa"`;
-      } else {
-        this.CODE_BIN = "./bin/*";
-      }
     }
 
     /* Start Legacy Code

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -71,16 +71,17 @@ export class Environment {
     this.isPortable = !!process.env.VSCODE_PORTABLE;
 
     this.OsType = process.platform as OsType;
-
     if (!this.isPortable) {
       this.PATH = resolve(this.context.globalStoragePath, "../../..").concat(
         "/"
       );
       this.USER_FOLDER = resolve(this.PATH, "User").concat("/");
       this.EXTENSION_FOLDER = resolve(
-        vscode.extensions.all[72].extensionPath,
+        vscode.extensions.all.filter(
+          extension => !extension.packageJSON.isBuiltin
+        )[0].extensionPath,
         ".."
-      ).concat("/"); // 0-71 are vscode built-in extensions that are in a separate folder. 72 is the first user-installed extension
+      ).concat("/"); // Gets first non-builtin extension's path
       if (this.OsType === OsType.Windows) {
         this.CODE_BIN = `for /r "bin" %a in (*.cmd) do "%~fa"`;
       } else {

--- a/src/environmentPath.ts
+++ b/src/environmentPath.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { resolve } from "path";
+import { normalize, resolve } from "path";
 import * as vscode from "vscode";
 import { OsType } from "./enums";
 
@@ -72,21 +72,25 @@ export class Environment {
     this.OsType = process.platform as OsType;
     if (!this.isPortable) {
       this.PATH = resolve(this.context.globalStoragePath, "../../..").concat(
-        "/"
+        normalize("/")
       );
-      this.USER_FOLDER = resolve(this.PATH, "User").concat("/");
+      this.USER_FOLDER = resolve(this.PATH, "User").concat(normalize("/"));
       this.EXTENSION_FOLDER = resolve(
         vscode.extensions.all.filter(
           extension => !extension.packageJSON.isBuiltin
         )[0].extensionPath,
         ".."
-      ).concat("/"); // Gets first non-builtin extension's path
+      ).concat(normalize("/")); // Gets first non-builtin extension's path
     }
 
     if (this.isPortable) {
       this.PATH = process.env.VSCODE_PORTABLE;
-      this.USER_FOLDER = resolve(this.PATH, "user-data/User").concat("/");
-      this.EXTENSION_FOLDER = resolve(this.PATH, "extensions").concat("/");
+      this.USER_FOLDER = resolve(this.PATH, "user-data/User").concat(
+        normalize("/")
+      );
+      this.EXTENSION_FOLDER = resolve(this.PATH, "extensions").concat(
+        normalize("/")
+      );
     }
 
     /* Start Legacy Code

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -229,7 +229,7 @@ export class PluginService {
           const installed = await new Promise<boolean>(res => {
             vscode.commands
               .executeCommand("workbench.extensions.installExtension", name)
-              .then(res);
+              .then(() => res(true));
           });
           if (installed) {
             remainingExtensions = remainingExtensions.filter(

--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -229,31 +229,38 @@ export class PluginService {
     notificationCallBack("TOTAL EXTENSIONS : " + missingExtensions.length);
     notificationCallBack("");
     notificationCallBack("");
-    missingExtensions.forEach(ext => {
-      const name = ext.publisher + "." + ext.name;
+    for (let i = 0; i < missingExtensions.length; i++) {
+      const ext = missingExtensions[i];
+      addedExtensions.push(
+        await PluginService.InstallExtension(ext, notificationCallBack)
+      );
+      notificationCallBack(
+        `INSTALLED EXTENSION ${missingExtensions.indexOf(ext) +
+          1}/${missingExtensions.length.toString()}`,
+        true
+      );
+      notificationCallBack("");
+      notificationCallBack("");
+    }
+    return addedExtensions;
+  }
+
+  public static InstallExtension(
+    extension: ExtensionInformation,
+    notificationCallBack: (...data: any[]) => void
+  ): Promise<ExtensionInformation> {
+    return new Promise(async (resolve, reject) => {
+      const name = extension.publisher + "." + extension.name;
       try {
         notificationCallBack(`INSTALLING EXTENSION: ${name}`);
-        vscode.commands.executeCommand(
-          "workbench.extensions.installExtension",
-          name
-        );
-        notificationCallBack("");
-        notificationCallBack(
-          "EXTENSION : " +
-            (missingExtensions.indexOf(ext) + 1) +
-            " / " +
-            missingExtensions.length.toString() +
-            " INSTALLED.",
-          true
-        );
-        notificationCallBack("");
-        notificationCallBack("");
-        addedExtensions.push(ext);
+        vscode.commands
+          .executeCommand("workbench.extensions.installExtension", name)
+          .then(() => {
+            resolve(extension);
+          });
       } catch (err) {
-        console.log(err);
+        reject(err);
       }
     });
-
-    return addedExtensions;
   }
 }

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -30,8 +30,7 @@ export class KeyValue<T, S> {
 
 export class CustomSettings {
   public ignoreUploadFiles: string[] = [
-    "state.vscdb",
-    "state.vscdb.backup",
+    "state.*",
     "syncLocalSettings.json",
     ".DS_Store",
     "sync.lock",

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -522,7 +522,7 @@ export class Sync {
                 try {
                   deletedExtensions = await PluginService.DeleteExtensions(
                     content,
-                    env.EXTENSION_FOLDER,
+                    env.CODE_BIN,
                     ignoredExtensions
                   );
                 } catch (uncompletedExtensions) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -539,7 +539,7 @@ export class Sync {
                   );
                   Commons.outputChannel.clear();
                   Commons.outputChannel.appendLine(
-                    `COMMAND LINE EXTENSION DOWNLOAD SUMMARY`
+                    `Realtime Extension Download Summary`
                   );
                   Commons.outputChannel.appendLine(`--------------------`);
                   Commons.outputChannel.show();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -522,8 +522,8 @@ export class Sync {
                 try {
                   deletedExtensions = await PluginService.DeleteExtensions(
                     content,
-                    ignoredExtensions,
-                    env.EXTENSION_FOLDER
+                    env.EXTENSION_FOLDER,
+                    ignoredExtensions
                   );
                 } catch (uncompletedExtensions) {
                   vscode.window.showErrorMessage(
@@ -549,6 +549,7 @@ export class Sync {
                 addedExtensions = await PluginService.InstallExtensions(
                   content,
                   ignoredExtensions,
+                  env.CODE_BIN,
                   (message: string, dispose: boolean) => {
                     if (!syncSetting.quietSync) {
                       Commons.outputChannel.appendLine(message);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -549,7 +549,6 @@ export class Sync {
                 addedExtensions = await PluginService.InstallExtensions(
                   content,
                   ignoredExtensions,
-                  env.CODE_BIN,
                   (message: string, dispose: boolean) => {
                     if (!syncSetting.quietSync) {
                       Commons.outputChannel.appendLine(message);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -522,7 +522,6 @@ export class Sync {
                 try {
                   deletedExtensions = await PluginService.DeleteExtensions(
                     content,
-                    env.CODE_BIN,
                     ignoredExtensions
                   );
                 } catch (uncompletedExtensions) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -522,8 +522,8 @@ export class Sync {
                 try {
                   deletedExtensions = await PluginService.DeleteExtensions(
                     content,
-                    env.ExtensionFolder,
-                    ignoredExtensions
+                    ignoredExtensions,
+                    env.EXTENSION_FOLDER
                   );
                 } catch (uncompletedExtensions) {
                   vscode.window.showErrorMessage(
@@ -534,30 +534,21 @@ export class Sync {
               }
 
               try {
-                let useCli = true;
-                const autoUpdate: boolean = vscode.workspace
-                  .getConfiguration("extensions")
-                  .get("autoUpdate");
-                useCli = autoUpdate && !env.isCoderCom;
-                if (useCli) {
-                  if (!syncSetting.quietSync) {
-                    Commons.outputChannel = vscode.window.createOutputChannel(
-                      "Code Settings Sync"
-                    );
-                    Commons.outputChannel.clear();
-                    Commons.outputChannel.appendLine(
-                      `COMMAND LINE EXTENSION DOWNLOAD SUMMARY`
-                    );
-                    Commons.outputChannel.appendLine(`--------------------`);
-                    Commons.outputChannel.show();
-                  }
+                if (!syncSetting.quietSync) {
+                  Commons.outputChannel = vscode.window.createOutputChannel(
+                    "Code Settings Sync"
+                  );
+                  Commons.outputChannel.clear();
+                  Commons.outputChannel.appendLine(
+                    `COMMAND LINE EXTENSION DOWNLOAD SUMMARY`
+                  );
+                  Commons.outputChannel.appendLine(`--------------------`);
+                  Commons.outputChannel.show();
                 }
 
                 addedExtensions = await PluginService.InstallExtensions(
                   content,
                   ignoredExtensions,
-                  env.OsType,
-                  env.isInsiders,
                   (message: string, dispose: boolean) => {
                     if (!syncSetting.quietSync) {
                       Commons.outputChannel.appendLine(message);


### PR DESCRIPTION
#### Short description of what this resolves:
This PR simplifies finding the code configuration folders and uses the API to install/uninstall extensions.

#### Changes proposed in this pull request:

- Find Code folder using the `globalStoragePath` and by traversing 3 directories up
- Find Extensions folder by getting a random extension and traversing up 1 directory
- Use VSCode API to install/uninstall extensions

**Fixes**: #668 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have tested this PR with the OSS version, VSCodium portable, and the official version (on Manjaro), and with the official version on Windows.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.

#### Progress:
- [x] Install extensions using API
- [x] Uninstall extensions using API
- [x] Get folders properly