### PR TITLE
Cleaned up toggling commented settings

### DIFF
--- a/src/pragmaUtil.ts
+++ b/src/pragmaUtil.ts
@@ -232,10 +232,14 @@ export default class PragmaUtil {
   private static readonly EnvPragmaWhiteSpacesSupportRegExp = /(?:env=(.+)host=)|(?:env=(.+)os=)|env=(.+)\n?/;
 
   private static toggleComments(line: string, shouldComment: boolean) {
-    if (shouldComment && !line.trim().startsWith("//")) {
-      return line.replace(/^(\s*)/, "$1// "); // use leading whitespaces for formmating
+    const isCommented = line.trim().startsWith("//");
+
+    if (shouldComment) {
+      // Replace with RegEx to help match indent size
+      return !isCommented ? line.replace(/^(\s*)/, "$1// ") : line;
     } else {
-      return line.replace(/\/\/\s*/, "");
+      // Only remove if line is commented
+      return isCommented ? line.replace(/\/\/\s*/, "") : line;
     }
   }
 

--- a/src/pragmaUtil.ts
+++ b/src/pragmaUtil.ts
@@ -233,9 +233,9 @@ export default class PragmaUtil {
 
   private static toggleComments(line: string, shouldComment: boolean) {
     if (shouldComment && !line.trim().startsWith("//")) {
-      return "  //" + line; // 2 spaces as formmating
+      return line.replace(/^(\s*)/, "$1// "); // use leading whitespaces for formmating
     } else {
-      return line.replace("//", "");
+      return line.replace(/\/\/\s*/, "");
     }
   }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Modified the toggleComments function to help go along with the format of the user's settings (e.g. spaces (amount) or tabs).
- Included fix by @ioprotium for [#865](https://github.com/shanalikhan/code-settings-sync/issues/865)


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
