### PR TITLE
Fix issues with webpack

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const CleanWebpackPlugin = require("clean-webpack-plugin").default;
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const webpack = require("webpack");
 
 /** @type WebpackOptions */


### PR DESCRIPTION
#### Short description of what this resolves:
The package `clean-webpack-plugin` was recently updated to use newer syntax, and this broke the webpack configuration. This PR fixes issues with building the extension because of the update. 

#### Changes proposed in this pull request:

Change 
```
const CleanWebpackPlugin = require("clean-webpack-plugin").default;
```
to
```
const { CleanWebpackPlugin } = require("clean-webpack-plugin");
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.