### PR TITLE
Install extensions in order

### DIFF
--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -179,9 +179,7 @@ export class PluginService {
           return selectedExtension;
         } catch (err) {
           throw new Error(
-            `Sync : Unable to delete extension ${selectedExtension.name} ${
-              selectedExtension.version
-            }: ${err}`
+            `Sync : Unable to delete extension ${selectedExtension.name} ${selectedExtension.version}: ${err}`
           );
         }
       })
@@ -213,37 +211,33 @@ export class PluginService {
     missingExtensions: ExtensionInformation[],
     notificationCallBack: (...data: any[]) => void
   ): Promise<ExtensionInformation[]> {
-    let remainingExtensions: ExtensionInformation[] = [...missingExtensions];
+    const addedExtensions: ExtensionInformation[] = [];
     const missingExtensionsCount = missingExtensions.length;
     notificationCallBack("TOTAL EXTENSIONS : " + missingExtensionsCount);
     notificationCallBack("");
     notificationCallBack("");
-    return Promise.all(
-      await missingExtensions.map(async ext => {
-        const name = ext.publisher + "." + ext.name;
-        try {
-          notificationCallBack("");
-          notificationCallBack(`[x] - EXTENSION: ${ext.name} - INSTALLING`);
-          await vscode.commands.executeCommand(
-            "workbench.extensions.installExtension",
-            name
-          );
-          remainingExtensions = remainingExtensions.filter(
-            remExt => remExt.name !== ext.name
-          );
-
-          notificationCallBack(`    - EXTENSION: ${ext.name} - INSTALLED.`);
-          notificationCallBack(
-            `      ${missingExtensions.length -
-              remainingExtensions.length} OF ${missingExtensionsCount} INSTALLED`,
-            true
-          );
-          notificationCallBack("");
-          return ext;
-        } catch (err) {
-          throw new Error(err);
-        }
-      })
-    );
+    for (const ext of missingExtensions) {
+      const name = ext.publisher + "." + ext.name;
+      try {
+        notificationCallBack("");
+        notificationCallBack(`[x] - EXTENSION: ${ext.name} - INSTALLING`);
+        await vscode.commands.executeCommand(
+          "workbench.extensions.installExtension",
+          name
+        );
+        notificationCallBack("");
+        notificationCallBack(`[x] - EXTENSION: ${ext.name} INSTALLED.`);
+        notificationCallBack(
+          `      ${missingExtensions.indexOf(ext) +
+            1} OF ${missingExtensionsCount} INSTALLED`,
+          true
+        );
+        notificationCallBack("");
+        addedExtensions.push(ext);
+      } catch (err) {
+        throw new Error(err);
+      }
+    }
+    return addedExtensions;
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Install extensions in order to sync `INSTALLING` and `INSTALLED` messages.

#### Changes proposed in this pull request:

- Use synchronous code to loop through the list and install extensions

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
