### PR TITLE
Properly throw errors

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -573,8 +573,8 @@ export class Sync {
                     }
                   }
                 );
-              } catch (extensions) {
-                addedExtensions = extensions;
+              } catch (err) {
+                throw new Error(err);
               }
             }
           } else {


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes an issue that could cause the download to fail if an error occurred during the extension installation process.

#### Changes proposed in this pull request:

- Throw error instead of setting `addedExtensions` to it.

**Fixes**: #912 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
#912 

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
