### PR TITLE
Resolve locale properly

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ export async function activate(context: vscode.ExtensionContext) {
   state.context = context;
   state.environment = new Environment();
 
-  await initLocalize();
+  await initLocalize(state.environment.USER_FOLDER);
 
   const sync = new Sync();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ export async function activate(context: vscode.ExtensionContext) {
   state.context = context;
   state.environment = new Environment();
 
-  await initLocalize(state.environment.USER_FOLDER);
+  await initLocalize();
 
   const sync = new Sync();
 

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs-extra";
 import * as path from "path";
 import { extensions } from "vscode";
+import { state } from "./state";
 
 interface IConfig {
   locale?: string;
@@ -23,13 +24,16 @@ export class Localize {
     const message: string = languagePack[key] || key;
     return this.format(message, args);
   }
-  public async init(userFolder: string) {
+  public async init() {
     this.options = {
       locale: "en"
     };
 
     try {
-      const pathToLocale = path.resolve(userFolder, "locale.json");
+      const pathToLocale = path.resolve(
+        state.environment.USER_FOLDER,
+        "locale.json"
+      );
       if (fs.existsSync(pathToLocale)) {
         const contents = fs.readFileSync(pathToLocale, "utf-8");
         this.options = {

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -23,7 +23,24 @@ export class Localize {
     const message: string = languagePack[key] || key;
     return this.format(message, args);
   }
-  public async init() {
+  public async init(userFolder: string) {
+    this.options = {
+      locale: "en"
+    };
+
+    try {
+      const pathToLocale = path.resolve(userFolder, "locale.json");
+      if (fs.existsSync(pathToLocale)) {
+        const contents = fs.readFileSync(pathToLocale, "utf-8");
+        this.options = {
+          ...this.options,
+          ...(contents ? JSON.parse(contents) : {})
+        };
+      }
+    } catch (err) {
+      //
+    }
+
     this.bundle = await this.resolveLanguagePack();
   }
   /**
@@ -100,20 +117,7 @@ export class Localize {
   }
 }
 
-let config: IConfig = {
-  locale: "en"
-};
-
-try {
-  config = Object.assign(
-    config,
-    JSON.parse((process.env as any).VSCODE_NLS_CONFIG)
-  );
-} catch (err) {
-  //
-}
-
-const instance = new Localize(config);
+const instance = new Localize();
 
 const init = instance.init.bind(instance);
 

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -12,7 +12,7 @@ interface ILanguagePack {
 
 export class Localize {
   private bundle: ILanguagePack;
-  constructor(private options: IConfig = {}) {}
+  private options: IConfig;
   /**
    * translate the key
    * @param key


### PR DESCRIPTION
#### Short description of what this resolves:
This PR uses `locale.json` to resolve the locale instead of environmental variables. This leads to better consistency in localizations.

#### Changes proposed in this pull request:

- Use `locale.json` as config for `localize.ts`

**Fixes**: #886 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by changing language and watching as the extension properly localizes it.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.