### PR TITLE
More understandable errors for @octokit/rest

### DIFF
--- a/src/service/github.service.ts
+++ b/src/service/github.service.ts
@@ -4,6 +4,7 @@ import * as GitHubApi from "@octokit/rest";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import * as vscode from "vscode";
 import Commons from "../commons";
+import { state } from "../state";
 import { File } from "./file.service";
 
 interface IEnv {
@@ -132,8 +133,9 @@ export class GitHubService {
     const promise = this.github.gists.get({ gist_id: GIST });
     const res = await promise.catch(err => {
       if (String(err).includes("HttpError: Not Found")) {
-        Commons.LogException(err, "Sync: Invalid Gist ID", true);
+        return Commons.LogException(err, "Sync: Invalid Gist ID", true);
       }
+      Commons.LogException(err, state.commons.ERROR_MESSAGE, true);
     });
     if (res) {
       return res;
@@ -183,8 +185,9 @@ export class GitHubService {
 
     const res = await promise.catch(err => {
       if (String(err).includes("HttpError: Not Found")) {
-        Commons.LogException(err, "Sync: Invalid Gist ID", true);
+        return Commons.LogException(err, "Sync: Invalid Gist ID", true);
       }
+      Commons.LogException(err, state.commons.ERROR_MESSAGE, true);
     });
 
     if (res) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -297,9 +297,6 @@ export class Sync {
         }
         let gistObj = await github.ReadGist(syncSetting.gist);
         if (!gistObj) {
-          vscode.window.showErrorMessage(
-            localize("cmd.updateSettings.error.readGistFail", syncSetting.gist)
-          );
           return;
         }
 
@@ -451,7 +448,6 @@ export class Sync {
       const res = await github.ReadGist(syncSetting.gist);
 
       if (!res) {
-        Commons.LogException(res, "Sync : Unable to Read Gist.", true);
         return;
       }
 
@@ -1095,7 +1091,6 @@ export class Sync {
     );
     const res = await github.ReadGist(syncSetting.gist);
     if (!res) {
-      Commons.LogException(res, "Sync : Unable to Read Gist.", true);
       return [];
     }
     const keys = Object.keys(res.data.files);


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adds more understandable errors for `@octokit/rest`.

#### Changes proposed in this pull request:

- Catch errors and show more understandable messages if gist id is incorrect.

**Fixes**: Every issue with `HttpError: Not Found`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by inputting fake gist id and checking for the custom error. Also doesn't break anything if gist id is correct.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.