### PR TITLE
Fix Safe Upload

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -88,7 +88,10 @@ export class Sync {
         localConfig.customConfig.githubEnterpriseUrl
       );
 
-      if (!localConfig.extConfig.forceUpload) {
+      if (
+        localConfig.customConfig.lastUpload &&
+        !localConfig.extConfig.forceUpload
+      ) {
         if (
           await github.IsGistNewer(
             localConfig.extConfig.gist,


### PR DESCRIPTION
#### Short description of what this resolves:
This PR only shows the "Gist newer" dialog if `lastUpload` isn't null

#### Changes proposed in this pull request:

- Check if `lastUpload` is null

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
