### PR TITLE
Add Button to Download Public Gist

### DIFF
--- a/src/service/webview.service.ts
+++ b/src/service/webview.service.ts
@@ -348,6 +348,30 @@ export class WebviewService {
             await state.commons.GetSettings()
           );
           break;
+        case "downloadPublicGist":
+          const [extConfig, customConfig] = await Promise.all([
+            state.commons.GetSettings(),
+            state.commons.GetCustomSettings()
+          ]);
+          const publicGist = await vscode.window.showInputBox({
+            placeHolder: localize("common.placeholder.enterGistId"),
+            ignoreFocusOut: true
+          });
+          if (!publicGist) {
+            break;
+          }
+          await state.commons.SetCustomSettings({
+            ...customConfig,
+            downloadPublicGist: true
+          });
+          await state.commons.SaveSettings({
+            ...extConfig,
+            gist: publicGist
+          });
+          vscode.window.showInformationMessage(
+            localize("cmd.otherOptions.warning.tokenNotRequire")
+          );
+          break;
       }
     });
     landingPanel.webview.html = content;

--- a/src/service/webview.service.ts
+++ b/src/service/webview.service.ts
@@ -371,6 +371,7 @@ export class WebviewService {
           vscode.window.showInformationMessage(
             localize("cmd.otherOptions.warning.tokenNotRequire")
           );
+          vscode.commands.executeCommand("extension.downloadSettings");
           break;
       }
     });

--- a/ui/landing-page/landing-page.html
+++ b/ui/landing-page/landing-page.html
@@ -71,6 +71,14 @@
               </div>
             </div>
           </div>
+          <div class="text-left my-2">
+            <a
+              href="#"
+              onclick="sendCommand('downloadPublicGist')"
+              title="Download Public Gist"
+              >Download Public Gist</a
+            >
+          </div>
         </div>
         <div>
           <h3 class="mx-auto mb-3 text-white-50a text-left">


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adds a button to the landing page to download public gist.

#### Changes proposed in this pull request:

- Add button to landing page
- Ask for gist id when clicked, and save it
- Enable `downloadPublicGist`

**Fixes**: https://github.com/shanalikhan/code-settings-sync/pull/876#issuecomment-507641582

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
