### PR TITLE
Fix safe upload

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -323,11 +323,22 @@ export class Sync {
           })
         ) {
           if (!localConfig.extConfig.forceUpload) {
-            vscode.window.setStatusBarMessage(
-              localize("cmd.updateSettings.info.uploadCanceled"),
-              3
+            const message = await vscode.window.showInformationMessage(
+              localize("common.prompt.gistNewer"),
+              "Yes"
             );
-            return;
+            if (message === "Yes") {
+              await state.commons.SaveSettings({
+                ...localConfig.extConfig,
+                forceUpload: true
+              });
+            } else {
+              vscode.window.setStatusBarMessage(
+                localize("cmd.updateSettings.info.uploadCanceled"),
+                3
+              );
+              return;
+            }
           }
         }
 
@@ -351,46 +362,40 @@ export class Sync {
 
       if (completed) {
         try {
-          const settingsUpdated = await state.commons.SaveSettings(syncSetting);
-          const customSettingsUpdated = await state.commons.SetCustomSettings(
-            customSettings
-          );
-          if (settingsUpdated && customSettingsUpdated) {
-            if (newGIST) {
-              vscode.window.showInformationMessage(
-                localize(
-                  "cmd.updateSettings.info.uploadingDone",
-                  syncSetting.gist
-                )
-              );
-            }
+          if (newGIST) {
+            vscode.window.showInformationMessage(
+              localize(
+                "cmd.updateSettings.info.uploadingDone",
+                syncSetting.gist
+              )
+            );
+          }
 
-            if (localConfig.publicGist) {
-              vscode.window.showInformationMessage(
-                localize("cmd.updateSettings.info.shareGist")
-              );
-            }
+          if (localConfig.publicGist) {
+            vscode.window.showInformationMessage(
+              localize("cmd.updateSettings.info.shareGist")
+            );
+          }
 
-            if (!syncSetting.quietSync) {
-              state.commons.ShowSummaryOutput(
-                true,
-                allSettingFiles,
-                null,
-                uploadedExtensions,
-                ignoredExtensions,
-                localConfig
-              );
-              vscode.window.setStatusBarMessage("").dispose();
-            } else {
-              vscode.window.setStatusBarMessage("").dispose();
-              vscode.window.setStatusBarMessage(
-                localize("cmd.updateSettings.info.uploadingSuccess"),
-                5000
-              );
-            }
-            if (syncSetting.autoUpload) {
-              await state.commons.HandleStartWatching();
-            }
+          if (!syncSetting.quietSync) {
+            state.commons.ShowSummaryOutput(
+              true,
+              allSettingFiles,
+              null,
+              uploadedExtensions,
+              ignoredExtensions,
+              localConfig
+            );
+            vscode.window.setStatusBarMessage("").dispose();
+          } else {
+            vscode.window.setStatusBarMessage("").dispose();
+            vscode.window.setStatusBarMessage(
+              localize("cmd.updateSettings.info.uploadingSuccess"),
+              5000
+            );
+          }
+          if (syncSetting.autoUpload) {
+            await state.commons.HandleStartWatching();
           }
         } catch (err) {
           Commons.LogException(err, state.commons.ERROR_MESSAGE, true);


### PR DESCRIPTION
#### Short description of what this resolves:
This PR allows the user to enable `forceUpload` if the gist contents are the same.

#### Changes proposed in this pull request:

- Show message box if gist contents are the same with option to enable `forceUpload`

**Fixes**: https://github.com/shanalikhan/code-settings-sync/pull/923#issuecomment-508031793


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
