### PR TITLE
Fix issue with Localize

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -9,7 +9,7 @@ export class Localize {
 
   public localize(key: string, ...args: string[]): string {
     const message = this.bundle[key] || key;
-    return this.format(message, args.flat());
+    return this.format(message, args);
   }
 
   private init() {


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes a **CRITICAL** issue in `localize.ts` that would cause the extension to crash. In a previous PR, I used `Array.flat()` to make sure the localization arguments were not nested arrays, but this caused many issues with VSCode and somehow got past my testing.

#### Changes proposed in this pull request:

- Don't use `Array.flat()`

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.

@shanalikhan This is a very important fix. It should be merged as soon as possible into `v3.4.0`.