### PR TITLE
Fix issue with forceUpload

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -111,7 +111,6 @@ export class Sync {
           );
           if (message === "Yes") {
             localConfig.extConfig.forceUpload = true;
-            await state.commons.SaveSettings(localConfig.extConfig);
           } else if (message === "Don't Show This Again") {
             await state.context.globalState.update(
               "gistNewer.dontShowThisAgain",
@@ -349,10 +348,7 @@ export class Sync {
               "Don't Show This Again"
             );
             if (message === "Yes") {
-              await state.commons.SaveSettings({
-                ...localConfig.extConfig,
-                forceUpload: true
-              });
+              syncSetting.forceUpload = true;
             } else if (message === "Don't Show This Again") {
               await state.context.globalState.update(
                 "gistNewer.dontShowThisAgain",


### PR DESCRIPTION
#### Short description of what this resolves:
The settings being saved would potentially overwrite `forceUpload` being set to true. This PR solves this by modifying the object that is used to save settings at the end.

#### Changes proposed in this pull request:

- Modify `syncSetting` instead of `localConfig.extConfig` because it is used at the end of the process in `state.commons.SaveSettings()`.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.