### PR TITLE
Landing Page: Don't Show This Again

### DIFF
--- a/src/service/webview.service.ts
+++ b/src/service/webview.service.ts
@@ -382,9 +382,8 @@ export class WebviewService {
         case "dontShowThisAgain":
           await state.context.globalState.update(
             "landingPage.dontShowThisAgain",
-            true
+            message.data
           );
-          landingPanel.dispose();
           break;
       }
     });

--- a/src/service/webview.service.ts
+++ b/src/service/webview.service.ts
@@ -306,6 +306,12 @@ export class WebviewService {
   }
 
   public OpenLandingPage() {
+    const dontShowThisAgain = state.context.globalState.get<boolean>(
+      "landingPage.dontShowThisAgain"
+    );
+    if (dontShowThisAgain) {
+      return;
+    }
     const webview = this.webviews[0];
     const releaseNotes = require("../../release-notes.json");
     const content: string = this.GenerateContent({
@@ -372,6 +378,13 @@ export class WebviewService {
             localize("cmd.otherOptions.warning.tokenNotRequire")
           );
           vscode.commands.executeCommand("extension.downloadSettings");
+          break;
+        case "dontShowThisAgain":
+          await state.context.globalState.update(
+            "landingPage.dontShowThisAgain",
+            true
+          );
+          landingPanel.dispose();
           break;
       }
     });

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -745,18 +745,16 @@ export class Sync {
       extSettings = new ExtensionConfig();
       localSettings = new CustomConfig();
 
-      await state.context.globalState.update(
-        "gistNewer.dontShowThisAgain",
-        false
-      );
+      await Promise.all([
+        state.context.globalState.update("gistNewer.dontShowThisAgain", false),
+        state.context.globalState.update("landingPage.dontShowThisAgain", false)
+      ]);
 
-      const extSaved: boolean = await state.commons.SaveSettings(extSettings);
-      const customSaved: boolean = await state.commons.SetCustomSettings(
-        localSettings
-      );
-      const lockExist: boolean = await FileService.FileExists(
-        state.environment.FILE_SYNC_LOCK
-      );
+      const [extSaved, customSaved, lockExist] = await Promise.all([
+        state.commons.SaveSettings(extSettings),
+        state.commons.SetCustomSettings(localSettings),
+        FileService.FileExists(state.environment.FILE_SYNC_LOCK)
+      ]);
 
       if (!lockExist) {
         fs.closeSync(fs.openSync(state.environment.FILE_SYNC_LOCK, "w"));

--- a/ui/landing-page/landing-page.html
+++ b/ui/landing-page/landing-page.html
@@ -120,6 +120,12 @@
             ><br />
             <a href="https://twitter.com/itsShanKhan">Follow me on Twitter</a
             ><br />
+            <a
+              href="#"
+              onclick="sendCommand('dontShowThisAgain')"
+              title="Don't show this again"
+              >Don't show this again</a
+            ><br />
           </div>
         </div>
       </div>

--- a/ui/landing-page/landing-page.html
+++ b/ui/landing-page/landing-page.html
@@ -120,12 +120,6 @@
             ><br />
             <a href="https://twitter.com/itsShanKhan">Follow me on Twitter</a
             ><br />
-            <a
-              href="#"
-              onclick="sendCommand('dontShowThisAgain')"
-              title="Don't show this again"
-              >Don't show this again</a
-            ><br />
           </div>
         </div>
       </div>
@@ -142,9 +136,7 @@
         <br />
       </div>
       <div class="col col-two">
-        <h3 class="mx-auto mb-3 text-white-50a">
-          Sponsors
-        </h3>
+        <h3 class="mb-3">Sponsors</h3>
         <p class="mx-auto mt-2 mb-3 text-white-50a">
           Settings Sync is looking for sponsors to display here. Contact me on
           <a href="https://twitter.com/itsShanKhan">Twitter</a> or
@@ -152,6 +144,20 @@
         </p>
       </div>
     </footer>
+    <form class="form dock-bottom-right">
+      <div class="custom-control custom-checkbox">
+        <input
+          class="custom-control-input checkbox"
+          type="checkbox"
+          id="customCheck1"
+          checked="true"
+          onclick="sendCommand('dontShowThisAgain', !this.checked)"
+        />
+        <label for="customCheck1" class="custom-control-label">
+          Show this page on startup
+        </label>
+      </div>
+    </form>
     <script defer src="@PWD/ui/shared/page-header.js"></script>
     <script defer src="@PWD/ui/shared/fonts.js"></script>
     <font-injector></font-injector>

--- a/ui/landing-page/landing-page.js
+++ b/ui/landing-page/landing-page.js
@@ -1,9 +1,10 @@
 // @ts-nocheck
 const vscode = acquireVsCodeApi();
 
-function sendCommand(args) {
+function sendCommand(command, data) {
   vscode.postMessage({
-    command: args
+    command,
+    data
   });
 }
 

--- a/ui/shared/styles.css
+++ b/ui/shared/styles.css
@@ -80,6 +80,18 @@ body.vscode-light {
   left: 4rem;
 }
 
+.dock-bottom-right {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background-color: rgb(42, 42, 42);
+  border-radius: 1.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
 .logo {
   padding-right: 0.5rem;
   filter: opacity(0.5);


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adds a button to not show the landing page, even if the extension is not configured.

#### Changes proposed in this pull request:

- Use `context.globalState` to keep track of preference
- Reset the preference when resetting extension settings
- Don't show the landing page if enabled

**Fixes**: https://github.com/shanalikhan/code-settings-sync/issues/959#issuecomment-511682067

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
