### PR TITLE
Safe upload

### DIFF
--- a/src/service/github.service.ts
+++ b/src/service/github.service.ts
@@ -145,7 +145,7 @@ export class GitHubService {
 
   public async IsGistNewer(
     GIST: string,
-    localLastUpload: Date
+    localLastDownload: Date
   ): Promise<boolean> {
     const gist = await this.ReadGist(GIST);
     if (!gist) {
@@ -155,10 +155,10 @@ export class GitHubService {
     try {
       gistCloudSetting = JSON.parse(gist.data.files.cloudSettings.content);
       const gistLastUpload = new Date(gistCloudSetting.lastUpload);
-      if (!localLastUpload) {
+      if (!localLastDownload) {
         return false;
       }
-      return gistLastUpload >= localLastUpload;
+      return gistLastUpload > localLastDownload;
     } catch (err) {
       return false;
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -258,7 +258,7 @@ export class Sync {
           if (syncSetting.gist != null && syncSetting.gist !== "") {
             const gistNewer = await github.IsGistNewer(
               syncSetting.gist,
-              new Date(customSettings.lastUpload)
+              new Date(customSettings.lastDownload)
             );
             if (gistNewer) {
               if (
@@ -293,6 +293,7 @@ export class Sync {
         }
 
         customSettings.lastUpload = dateNow;
+        customSettings.lastDownload = dateNow;
         let gistObj = await github.ReadGist(syncSetting.gist);
 
         if (!gistObj) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -284,7 +284,7 @@ export class Sync {
               } else {
                 vscode.window.setStatusBarMessage(
                   localize("cmd.updateSettings.info.uploadCanceled"),
-                  3
+                  3000
                 );
                 return;
               }
@@ -367,7 +367,7 @@ export class Sync {
             } else {
               vscode.window.setStatusBarMessage(
                 localize("cmd.updateSettings.info.uploadCanceled"),
-                3
+                3000
               );
               return;
             }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -328,17 +328,17 @@ export class Sync {
 
         if (
           !allSettingFiles.some(fileToUpload => {
-            if (fileToUpload.fileName === "cloudSettings") {
+            if (fileToUpload.gistName === "cloudSettings") {
               return false;
             }
-            if (!gistObj.data.files[fileToUpload.fileName]) {
+            if (!gistObj.data.files[fileToUpload.gistName]) {
               return true;
             }
             if (
-              gistObj.data.files[fileToUpload.fileName].content !==
+              gistObj.data.files[fileToUpload.gistName].content !==
               fileToUpload.content
             ) {
-              console.info(`Sync: file ${fileToUpload.fileName} has changed`);
+              console.info(`Sync: file ${fileToUpload.gistName} has changed`);
               return true;
             }
           })


### PR DESCRIPTION
#### Short description of what this resolves:
Allows uploading settings without forcing when multiple machines are uploading settings.

Example failing scenario:

- Machine A uploads settings to cloud
- Machine B downloads these settings
- Machine B changes settings and uploads them to the cloud
- Machine A downloads the settings
- Machine A changes settings and tries to upload them
    
The last upload attempt fails because A's last upload time is before the cloud's last upload time, even though A downloaded the settings.  A forced upload is needed in order to upload the settings.  It, therefore, makes sense to compare against the local download time.

#### Changes proposed in this pull request:

- Change IsGistNewer to compare the gist upload time to the local download time
- On an upload, set the local download time to the same upload time
- Fix bug with the check to see if files have changed.  This prevents "empty" uploads when snippet files are present.
- Fix some status bar message timeouts so that upload canceled messages are visible.

**Fixes**: #1016

#### How Has This Been Tested?
- Tested single machine scenario where a single machine is uploading and downloading settings.
    - Verify download downloads only when needed
    - Verify upload triggers popup when there are no local changes
    - Verify upload is performed when there is a local change
- Tested failing two-machine scenario noted above  
- All testing accomplished with two Linux machines.

#### Screenshots (if appropriate):
n/a

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
