### PR TITLE
Add macOS shortcuts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ All extensions and complete User Folder that Contains
 ```
 1. Upload Key : Shift + Alt + U
 2. Download Key : Shift + Alt + D
+
+(on macOS: Shift + Option + U / Shift + Option + D
 ```
 
 ## Configure Settings Sync
@@ -99,7 +101,7 @@ You can always **verify created gist** by going to `https://gist.github.com` and
 
 ## Upload Your Settings
 
-**Press Shift + Alt + U**
+**Press Shift + Alt + U** (macOS: Shift + Option + U)
 
 > Type ">Sync" In Command Palette into order download / upload
 
@@ -109,7 +111,7 @@ Once you select upload, after uploading the settings. You will see the Summary d
 
 ## Download your Settings
 
-**Press Shift + Alt + D**
+**Press Shift + Alt + D** (macOS: Shift + Option + D)
 
 > Type ">Sync" In Command Palette into order download / upload
 


### PR DESCRIPTION
#### Short description of what this resolves:

The extension works just as well on Mac, we might as well be explicit about how macOS users are to interact with it.

#### Changes proposed in this pull request:

Add macOS shortcuts to the README file.

#### How Has This Been Tested?
n/a

#### Screenshots (if appropriate):
n/a

#### Checklist:
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
