### PR TITLE
Add missing closing parenthesis in macOS shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ All extensions and complete User Folder that Contains
 1. Upload Key : Shift + Alt + U
 2. Download Key : Shift + Alt + D
 
-(on macOS: Shift + Option + U / Shift + Option + D
+(on macOS: Shift + Option + U / Shift + Option + D)
 ```
 
 ## Configure Settings Sync


### PR DESCRIPTION
#### Short description of what this resolves:

Add missing closing parenthesis in macOS shortcut

#### How Has This Been Tested?
n/a

#### Screenshots (if appropriate):
n/a

#### Checklist:
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
