### PR TITLE
silencing share gist info message on quietSync

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -404,7 +404,7 @@ export class Sync {
             );
           }
 
-          if (optArgument) {
+          if (!syncSetting.quietSync && optArgument) {
             vscode.window.showInformationMessage(
               localize("cmd.updateSettings.info.shareGist")
             );


### PR DESCRIPTION
#### Short description of what this resolves:

Prevents cmd.updateSettings.info.shareGist from showing as a vscode information message during auto upload when quietSync is enabled.

#### Changes proposed in this pull request:

- Adds condition to if statement that displays message requiring quietSync to be false to display.
- Only effects the information message statement. No other code lines would be effected.

**Fixes**: #1033 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have not been able to test this personally. I am having trouble running the extension in the debugger so I have not verified operation. Hoping to elicit some help on Slack or here to consider this done since I'm thinking the solution takes priority over my education. :)


#### Screenshots (if appropriate):
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
