### PR TITLE
fix: mistranslation in japanese

### DIFF
--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -109,7 +109,7 @@
   "common.prompt.restartCode": "拡張機能と設定を適用するためにリロードしますか？",
   "common.prompt.gistForceUpload": "Sync: アップロードにより、GitHub Gistの設定が置き換えられます。 設定をダウンロードするか、強制アップロードを行うことを検討してください。 それでも強制的にアップロードしますか？",
   "common.prompt.gistNewer": "Sync: Gistの設定は、最後にダウンロードしてから変更されています。 とにかく、現在のローカル設定をGistにアップロードしますか？",
-  "common.button.no": "番号",
+  "common.button.no": "いいえ",
   "common.button.yes": "はい",
   "ext.globalConfig.token.name": "アクセストークン",
   "ext.globalConfig.token.placeholder": "トークンを入力してください",


### PR DESCRIPTION
#### Short description of what this resolves:

fix mistranslation in `package.nls.ja.json`

- `common.button.no`
  - ❌ `番号`
    - It means NUMBER.
    - reference) https://jisho.org/search/%E7%95%AA%E5%8F%B7
  - ⭕ `いいえ`
    - It means NO.
    - reference) https://jisho.org/search/%E3%81%84%E3%81%84%E3%81%88

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
