### PR TITLE
i18n miss-translation fix (ja_JP)

### DIFF
--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -109,7 +109,7 @@
   "common.prompt.restartCode": "拡張機能と設定を適用するためにリロードしますか？",
   "common.prompt.gistForceUpload": "Sync: アップロードにより、GitHub Gistの設定が置き換えられます。 設定をダウンロードするか、強制アップロードを行うことを検討してください。 それでも強制的にアップロードしますか？",
   "common.prompt.gistNewer": "Sync: Gistの設定は、最後にダウンロードしてから変更されています。 とにかく、現在のローカル設定をGistにアップロードしますか？",
-  "common.button.no": "番号",
+  "common.button.no": "いいえ",
   "common.button.yes": "はい",
   "ext.globalConfig.token.name": "アクセストークン",
   "ext.globalConfig.token.placeholder": "トークンを入力してください",


### PR DESCRIPTION
## Short description of what this resolves:
There's a miss-translation in `package.nls.ja.json` .
I know `no` in `common.button.no` means `deny` and then it should be "いいえ"(iie) in Japanese, but the translation in this version "番号"(bangou) means "number" in Japanese.

#### Changes proposed in this pull request:
- Fix translation in Japanese

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- No Tests are performed because this is a simple translation fix.

#### Screenshots (if appropriate):
None

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
