### PR TITLE
Correct the translation of ext.config.autoUpload in zh-tw

### DIFF
--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -100,7 +100,7 @@
   "common.prompt.restartCode": "你是否要重新啟動 VSCode 以應用延伸模組和設定？",
   "ext.config.autoDownload": "設定為 true 在編輯器打開時自動下載線上設定。[需要重啟]",
   "ext.config.autoDownload.name": "自動下載",
-  "ext.config.autoUpload": "設定為 true 在編輯器打開時自動上傳本機設定。[需要重啟]",
+  "ext.config.autoUpload": "設定為 true 在設定更新後自動上傳本機設定。[需要重啟]",
   "ext.config.autoUpload.name": "自動上傳",
   "ext.config.forceDownload": "設定為 true 將會下載線上設定，即便本機已有更新的設定。",
   "ext.config.forceDownload.name": "強制下載",


### PR DESCRIPTION
#### Short description of what this resolves:
The zh-tw translation of ext.config.autoUpload is incorrect.
It was like "Set it true to Auto Upload the settings on `code start`. [Code Restart Required]".

#### Changes proposed in this pull request:
Correct the translation string of `ext.config.autoUpload`.

**Fixes**: None

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
OS: Windows 10 Enterprise [10.0.16299.1625]
I followed the [document](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) and modified the json file locally.
Ran it with debugger and saw the correct string in vscode.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11660755/75306182-43d1bb80-5883-11ea-806c-c6a94ae22ff8.png)


#### Checklist:
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
