### PR TITLE
handle extension installing errors

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -6,7 +6,10 @@ import { ExtensionConfig } from "./models/extensionConfig.model";
 import { LocalConfig } from "./models/localConfig.model";
 import { IExtensionState } from "./models/state.model";
 import { File, FileService } from "./service/file.service";
-import { ExtensionInformation } from "./service/plugin.service";
+import {
+  ExtensionInformation,
+  InstalledExtensionsSummary
+} from "./service/plugin.service";
 import { AutoUploadService } from "./service/watcher/autoUpload.service";
 import { WebviewService } from "./service/webview.service";
 
@@ -461,7 +464,7 @@ export default class Commons {
     upload: boolean,
     files: File[],
     removedExtensions: ExtensionInformation[],
-    addedExtensions: ExtensionInformation[],
+    extensionsInstallSummary: InstalledExtensionsSummary,
     ignoredExtensions: ExtensionInformation[],
     syncSettings: LocalConfig
   ) {
@@ -535,15 +538,25 @@ export default class Commons {
       }
     }
 
-    if (addedExtensions) {
+    if (extensionsInstallSummary) {
       outputChannel.appendLine(``);
       outputChannel.appendLine(`Extensions Added:`);
 
-      if (addedExtensions.length === 0) {
+      if (extensionsInstallSummary.addedExtensions.length === 0) {
         outputChannel.appendLine(`  No extensions installed.`);
       }
 
-      addedExtensions.forEach(extn => {
+      extensionsInstallSummary.addedExtensions.forEach(extn => {
+        outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+      });
+
+      if (extensionsInstallSummary.failedExtensions.length !== 0) {
+        outputChannel.appendLine(
+          `  ${extensionsInstallSummary.failedExtensions.length} extensions failed to install.`
+        );
+      }
+
+      extensionsInstallSummary.failedExtensions.forEach(extn => {
         outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
       });
     }

--- a/src/service/github/gist.service.ts
+++ b/src/service/github/gist.service.ts
@@ -11,7 +11,11 @@ import { LocalConfig } from "../../models/localConfig.model";
 import { IExtensionState } from "../../models/state.model";
 import PragmaUtil from "../../pragmaUtil";
 import { File, FileService } from "../file.service";
-import { ExtensionInformation, PluginService } from "../plugin.service";
+import {
+  ExtensionInformation,
+  InstalledExtensionsSummary,
+  PluginService
+} from "../plugin.service";
 import { GitHubService } from "./github.service";
 
 export class GistService implements ISyncService {
@@ -62,7 +66,7 @@ export class GistService implements ISyncService {
         return;
       }
 
-      let addedExtensions: ExtensionInformation[] = [];
+      let extensionsInstallSummary: InstalledExtensionsSummary;
       let deletedExtensions: ExtensionInformation[] = [];
       const ignoredExtensions: string[] =
         customSettings.ignoreExtensions || new Array<string>();
@@ -203,7 +207,7 @@ export class GistService implements ISyncService {
                   Commons.outputChannel.show();
                 }
 
-                addedExtensions = await PluginService.InstallExtensions(
+                extensionsInstallSummary = await PluginService.InstallExtensions(
                   content,
                   ignoredExtensions,
                   (message: string, dispose: boolean) => {
@@ -306,11 +310,14 @@ export class GistService implements ISyncService {
             false,
             updatedFiles,
             deletedExtensions,
-            addedExtensions,
+            extensionsInstallSummary,
             null,
             localSettings
           );
-          if (deletedExtensions.length > 0 || addedExtensions.length > 0) {
+          if (
+            deletedExtensions.length > 0 ||
+            extensionsInstallSummary.addedExtensions.length > 0
+          ) {
             const message = await vscode.window.showInformationMessage(
               localize("common.prompt.restartCode"),
               "Yes"
@@ -662,7 +669,7 @@ export class GistService implements ISyncService {
               true,
               allSettingFiles,
               null,
-              uploadedExtensions,
+              { addedExtensions: uploadedExtensions, failedExtensions: [] },
               ignoredExtensions,
               localConfig
             );


### PR DESCRIPTION
#### Short description of what this resolves:
Don't hang if there's an error installing some extension

#### Changes proposed in this pull request:

- Do not silently throw an error and freeze when something goes wrong when installing an extension
- Instead, show all the errors to the user

**Fixes**: #1227 #1202 #1144

#### How Has This Been Tested?
Tested downloading settings from a gist with an extension, which was removed from the marketplace. Also tried uploading, everything seems to work.

#### Screenshots (if appropriate):


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [-] My change requires a change to the documentation and GitHub Wiki.
- [-] I have updated the documentation and Wiki accordingly.
