### PR TITLE
Use typescript from node_modules for test_build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,8 +13,8 @@
     {
       "label": "test_build",
       "type": "shell",
-      "command": "tsc",
-      "args": ["-p", "./"]
+      "command": "npx",
+      "args": ["tsc", "-p", "./"]
     }
   ]
 }

--- a/test/service/fileService/fileService.test.ts
+++ b/test/service/fileService/fileService.test.ts
@@ -1,3 +1,5 @@
+import { sep as pathSeparatop } from "path";
+
 import { expect } from "chai";
 
 import { File, FileService } from "../../../src/service/file.service";
@@ -31,6 +33,7 @@ describe("FileService", () => {
       "hoge/piyo",
       "hoge.txt"
     );
-    expect(actual).to.be.equals("/User/path/to/hoge/piyo/hoge.txt");
+    expect(actual).to.be.equals(
+      `/User/path/to${pathSeparatop}hoge/piyo${pathSeparatop}hoge.txt`);
   });
 });


### PR DESCRIPTION
#### Short description of what this resolves:
Run `npx tsc` on build instead of global

**Fixes**: #

#### How Has This Been Tested?
Tests succeed even without a globally installed typescript(at least on my linux host)

#### Screenshots (if appropriate):


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
