### PR TITLE
Fix @octokit/rest import

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@octokit/rest": "^16.35.0",
+    "@octokit/rest": "^16.43.2",
     "adm-zip": "^0.4.13",
     "const": "^1.0.0",
     "express": "^4.17.1",

--- a/src/service/github/github.service.ts
+++ b/src/service/github/github.service.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as GitHubApi from "@octokit/rest";
+import { Octokit as GitHubApi } from "@octokit/rest";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import * as vscode from "vscode";
 import Commons from "../../commons";


### PR DESCRIPTION
#### Short description of what this resolves:
On fresh `npm install` we got "@octokit/rest": "16.43.2" that looks to have some braking changes and compilation fails.

```
> Executing task: npm run compile --loglevel silent <
...
ERROR in /home/n4nn31355/_PROJECTS/n4nn31355/code-settings-sync/src/service/github/github.service.ts
./src/service/github/github.service.ts
[tsl] ERROR in /home/n4nn31355/_PROJECTS/n4nn31355/code-settings-sync/src/service/github/github.service.ts(21,19)
      TS2709: Cannot use namespace 'GitHubApi' as a type.

ERROR in /home/n4nn31355/_PROJECTS/n4nn31355/code-settings-sync/src/service/github/github.service.ts
./src/service/github/github.service.ts
[tsl] ERROR in /home/n4nn31355/_PROJECTS/n4nn31355/code-settings-sync/src/service/github/github.service.ts(51,38)
      TS2694: Namespace '"/home/n4nn31355/_PROJECTS/n4nn31355/code-settings-sync/node_modules/@octokit/rest/index"' has no exported member 'Options'
...
```

#### How Has This Been Tested?
Build and extension work again.

#### Checklist:
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.