### PR TITLE
Fixed both nested array objects commenting and removal of multi-line block comments

### DIFF
--- a/src/pragmaUtil.ts
+++ b/src/pragmaUtil.ts
@@ -226,7 +226,7 @@ export default class PragmaUtil {
   }
 
   public static removeAllComments(text: string): string {
-    return text.replace(/(?<!["'].*)\s*(\/\/.+)|(\/\*.+\*\/)(?!["'].*)/g, "");
+    return text.replace(/(?<!["'].*)\s*(\/\/.+)|(?<!["'].*)(\/\*(.|\n)+?\*\/)(?!["'].*)(?!["'].*)/g, "");
   }
 
   // FIXME: test eslint(no-useless-escape)
@@ -240,7 +240,7 @@ export default class PragmaUtil {
   private static readonly EnvPragmaWhiteSpacesSupportRegExp = /(?:env=(.+)host=)|(?:env=(.+)os=)|env=(.+)\n?/;
   // FIXME: test eslint(no-useless-escape)
   // eslint-disable-next-line no-useless-escape
-  private static readonly OpenBlockRegExp = /['"]\s*?:\s*[{\[]+\n*/;
+  private static readonly OpenBlockRegExp = /[{\[]\s*\n*$/;
   // Use negative lookahead/behind to avoid errors with strings containing closing brackets
   private static readonly CloseBlockRegExp = /(?<!["'].*)[}\]]+(?!["'].*)/;
 

--- a/test/pragmaUtil/index.ts
+++ b/test/pragmaUtil/index.ts
@@ -101,4 +101,44 @@ describe("Process before upload", function() {
       .and.to.match(/\/{2}\s+},/)
       .and.to.match(/\s+"mac"/);
   });
+
+  it("should parse multi-line settings with nested array objects", () => {
+    const commentedSettings = `{
+      // @sync os=linux
+      "multi": {
+            "setting": false,
+            "settingWithBrackets": "{} []",
+            "multi": {
+            },
+            "nested": [
+                {
+                    "nestedSettingItemProp1": 1
+                },
+                {
+                    "nestedSettingItemProp2": 2
+                },
+                {
+                    "nestedSettingItemProp3": 3
+                }
+            ]
+      },
+      // @sync os=mac
+      "mac": 1
+    }`;
+    const processed = PragmaUtil.processBeforeWrite(
+      commentedSettings,
+      commentedSettings,
+      OsType.Mac,
+      null
+    );
+    expect(processed)
+      .to.match(/\/{2}\s+"multi"/)
+      .and.to.match(/\/{2}\s+"setting"/)
+      .and.to.match(/\/{2}\s+"settingWithBrackets"/)
+      .and.to.match(/\/{2}\s+"nestedSettingItemProp1"/)
+      .and.to.match(/\/{2}\s+"nestedSettingItemProp2"/)
+      .and.to.match(/\/{2}\s+"nestedSettingItemProp3"/)
+      .and.to.match(/\/{2}\s+},/)
+      .and.to.match(/\s+"mac"/);
+  });
 });

--- a/test/pragmaUtil/testSettings.txt
+++ b/test/pragmaUtil/testSettings.txt
@@ -30,6 +30,11 @@
     // @sync-ignore
     "test4": 12,
 
+    /*
+    "test6": 12,
+    "test7": 12,
+    */
+
     // @sync ignore
     "test5": 12
 }


### PR DESCRIPTION
#### Short description of what this resolves:

- Nested objects in an array would not comment correctly when downloading/uploading.
- Multi-line block comments were not being removed with `removeAllComments`.

#### Changes proposed in this pull request:

* Fixed nested array objects commenting
* Added test for nested array objects commenting
* Fixed removal of multi line block comments
* Updated testSettings.txt for `removal of multi line block comments` tests

#### How Has This Been Tested?
- Added test for nested objects in an array,
- Updated `testSettings.txt` to include a multi-line comment for removal test.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and GitHub Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
