### PR TITLE
Do a quiet sync by default - resolves #1256

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         },
         "sync.quietSync": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%ext.config.quietSync%"
         },
         "sync.removeExtensions": {


### PR DESCRIPTION
#### Short description of what this resolves:
#1256

#### Changes proposed in this pull request:
Do a quiet sync by default, to stop poping out the "Output" window and stealing focus.
