### PR TITLE
don't choke whole settings download if an extension fails to install

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -441,6 +441,7 @@ export default class Commons {
     files: File[],
     removedExtensions: ExtensionInformation[],
     addedExtensions: ExtensionInformation[],
+    failedToAddExtensions: ExtensionInformation[],
     ignoredExtensions: ExtensionInformation[],
     syncSettings: LocalConfig
   ) {
@@ -520,6 +521,19 @@ export default class Commons {
       }
 
       addedExtensions.forEach(extn => {
+        outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
+      });
+    }
+
+    if (failedToAddExtensions) {
+      outputChannel.appendLine(``);
+      outputChannel.appendLine(`Extensions Failed to be Added:`);
+
+      if (addedExtensions.length === 0) {
+        outputChannel.appendLine(`  No extensions failed to add.`);
+      }
+
+      failedToAddExtensions.forEach(extn => {
         outputChannel.appendLine(`  ${extn.name} v${extn.version}`);
       });
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -399,6 +399,7 @@ export class Sync {
               allSettingFiles,
               null,
               uploadedExtensions,
+              null,
               ignoredExtensions,
               localConfig
             );
@@ -466,6 +467,7 @@ export class Sync {
       }
 
       let addedExtensions: ExtensionInformation[] = [];
+      let failedToAddExtensions: ExtensionInformation[] = [];
       let deletedExtensions: ExtensionInformation[] = [];
       const ignoredExtensions: string[] =
         customSettings.ignoreExtensions || new Array<string>();
@@ -603,7 +605,7 @@ export class Sync {
                   Commons.outputChannel.show();
                 }
 
-                addedExtensions = await PluginService.InstallExtensions(
+                ({ addedExtensions, failedToAddExtensions } = await PluginService.InstallExtensions(
                   content,
                   ignoredExtensions,
                   (message: string, dispose: boolean) => {
@@ -619,7 +621,7 @@ export class Sync {
                       }
                     }
                   }
-                );
+                ));
               } catch (err) {
                 throw new Error(err);
               }
@@ -702,6 +704,7 @@ export class Sync {
             updatedFiles,
             deletedExtensions,
             addedExtensions,
+            failedToAddExtensions,
             null,
             localSettings
           );


### PR DESCRIPTION
in the FOSS version of vscode, vscodium [1], some extensions are not available.

attempting to download settings would thus completely fail
unless you manually specified extensions to ignore, which is a chore.

now, it all works automatically just fine.

[1] https://github.com/VSCodium/vscodium

tested out on installed vscodium version & was able to successfully download settings,
even tho some extensions were missing.
