### PR TITLE
fix(settings): reset tooltip on HTML append

### DIFF
--- a/ui/settings/settings.js
+++ b/ui/settings/settings.js
@@ -1,13 +1,30 @@
 // @ts-nocheck
 
 function appendHTML(parent, html) {
-  var div = document.createElement("div");
-  div.innerHTML = html;
-  while (div.children.length > 0) {
-    parent.appendChild(div.children[0]);
+  // Create a temporary container for the HTML string
+  const tempDiv = document.createElement("div");
+  tempDiv.innerHTML = html;
+
+  // Move all child elements from the temporary container to the parent
+  while (tempDiv.children.length > 0) {
+    parent.appendChild(tempDiv.children[0]);
   }
-  div.remove();
+
+  // Remove the temporary container to clean up the DOM
+  tempDiv.remove();
+
+  // Destroy all existing tooltips to prevent duplication
+  const tooltipElements = document.querySelectorAll('[data-toggle="tooltip"]');
+  tooltipElements.forEach((tooltip) => {
+    if ($(tooltip).data("bs.tooltip")) {
+      $(tooltip).tooltip("dispose");
+    }
+  });
+
+  // Reinitialize tooltips for the updated elements
+  $('[data-toggle="tooltip"]').tooltip({ container: "body" });
 }
+
 
 const vscode = acquireVsCodeApi();
 


### PR DESCRIPTION
### Description
This PR addresses an issue where tooltips flicker when dynamically added HTML elements contain `data-toggle="tooltip"` attributes.

### Changes Made
- Added logic to dispose of existing tooltip instances before initializing new ones.
- Ensured tooltips are correctly attached to dynamically added elements.

### Steps to Reproduce
1. Dynamically add an element with a tooltip (`data-toggle="tooltip"`) to the DOM.
2. Hover over the new element and observe the flickering issue.

### Expected Behavior
Tooltips should appear correctly without flickering or duplication.



##### I wasn't able to fully test the changes as I couldn't set up the full environment. However, based on my understanding of the issue and the codebase, this fix should address the tooltip flickering issue. Please let me know if additional adjustments are needed.

