### PR TITLE
Upload only changed settings files

### DIFF
--- a/src/service/gistChange.service.ts
+++ b/src/service/gistChange.service.ts
@@ -1,0 +1,50 @@
+"use strict";
+
+import { File } from "./file.service";
+
+export interface IGistFileMap {
+  [fileName: string]: {
+    content?: string;
+  };
+}
+
+export class GistChangeService {
+  public static GetChangedSettingFiles(
+    allSettingFiles: File[],
+    gistFiles: IGistFileMap
+  ): File[] {
+    return allSettingFiles.filter(fileToUpload => {
+      if (fileToUpload.gistName === "cloudSettings") {
+        return false;
+      }
+      if (!gistFiles[fileToUpload.gistName]) {
+        return true;
+      }
+      return gistFiles[fileToUpload.gistName].content !== fileToUpload.content;
+    });
+  }
+
+  public static GetFilesToUpload(
+    allSettingFiles: File[],
+    gistFiles: IGistFileMap,
+    forceUpload: boolean
+  ): File[] {
+    if (forceUpload) {
+      return allSettingFiles;
+    }
+
+    const changedSettingFiles = GistChangeService.GetChangedSettingFiles(
+      allSettingFiles,
+      gistFiles
+    );
+
+    return allSettingFiles.filter(fileToUpload => {
+      return (
+        fileToUpload.gistName === "cloudSettings" ||
+        changedSettingFiles.some(
+          changedFile => changedFile.gistName === fileToUpload.gistName
+        )
+      );
+    });
+  }
+}

--- a/src/service/github.service.ts
+++ b/src/service/github.service.ts
@@ -164,12 +164,16 @@ export class GitHubService {
     }
   }
 
-  public UpdateGIST(gistObject: any, files: File[]): any {
+  public UpdateGIST(
+    gistObject: any,
+    files: File[],
+    localFiles: File[] = files
+  ): any {
     const allFiles: string[] = Object.keys(gistObject.data.files);
     for (const fileName of allFiles) {
       let exists = false;
 
-      for (const settingFile of files) {
+      for (const settingFile of localFiles) {
         if (settingFile.gistName === fileName) {
           exists = true;
         }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -11,6 +11,7 @@ import { ExtensionConfig } from "./models/extensionConfig.model";
 import { LocalConfig } from "./models/localConfig.model";
 import PragmaUtil from "./pragmaUtil";
 import { File, FileService } from "./service/file.service";
+import { GistChangeService } from "./service/gistChange.service";
 import { GitHubService } from "./service/github.service";
 import { ExtensionInformation, PluginService } from "./service/plugin.service";
 import { state } from "./state";
@@ -226,6 +227,7 @@ export class Sync {
       allSettingFiles.push(file);
 
       let completed: boolean = false;
+      let filesToUpload: File[] = allSettingFiles;
 
       let newGIST: boolean = false;
       try {
@@ -284,23 +286,26 @@ export class Sync {
           localConfig.publicGist = true;
         }
 
-        if (
-          !allSettingFiles.some(fileToUpload => {
-            if (fileToUpload.gistName === "cloudSettings") {
-              return false;
-            }
-            if (!gistObj.data.files[fileToUpload.gistName]) {
-              return true;
-            }
-            if (
-              gistObj.data.files[fileToUpload.gistName].content !==
-              fileToUpload.content
-            ) {
-              console.info(`Sync: file ${fileToUpload.gistName} has changed`);
-              return true;
-            }
-          })
-        ) {
+        const changedSettingFiles = GistChangeService.GetChangedSettingFiles(
+          allSettingFiles,
+          gistObj.data.files
+        );
+
+        changedSettingFiles.forEach(fileToUpload => {
+          if (!gistObj.data.files[fileToUpload.gistName]) {
+            console.info(`Sync: file ${fileToUpload.gistName} is new`);
+          } else {
+            console.info(`Sync: file ${fileToUpload.gistName} has changed`);
+          }
+        });
+
+        filesToUpload = GistChangeService.GetFilesToUpload(
+          allSettingFiles,
+          gistObj.data.files,
+          localConfig.extConfig.forceUpload
+        );
+
+        if (changedSettingFiles.length === 0) {
           // Gist files are the same as the local files.
           if (!localConfig.extConfig.forceUpload) {
             vscode.window.setStatusBarMessage(
@@ -359,7 +364,7 @@ export class Sync {
           3000
         );
 
-        gistObj = github.UpdateGIST(gistObj, allSettingFiles);
+        gistObj = github.UpdateGIST(gistObj, filesToUpload, allSettingFiles);
         completed = await github.SaveGIST(gistObj.data);
         if (!completed) {
           vscode.window.showErrorMessage(
@@ -396,7 +401,7 @@ export class Sync {
           if (!syncSetting.quietSync) {
             state.commons.ShowSummaryOutput(
               true,
-              allSettingFiles,
+              filesToUpload,
               null,
               uploadedExtensions,
               ignoredExtensions,

--- a/test/service/gistChange/gistChangeService.test.ts
+++ b/test/service/gistChange/gistChangeService.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+
+import { File } from "../../../src/service/file.service";
+import { GistChangeService } from "../../../src/service/gistChange.service";
+
+describe("GistChangeService", () => {
+  const unchanged = new File("settings.json", "same", "", "settings.json");
+  const changed = new File("keybindings.json", "new", "", "keybindings.json");
+  const created = new File("snippets|demo.json", "created", "", "snippets|demo.json");
+  const cloudSettings = new File("cloudSettings", "metadata", "", "cloudSettings");
+  const allFiles = [unchanged, changed, created, cloudSettings];
+  const gistFiles = {
+    "settings.json": { content: "same" },
+    "keybindings.json": { content: "old" }
+  };
+
+  it("returns only new and changed setting files", () => {
+    const result = GistChangeService.GetChangedSettingFiles(allFiles, gistFiles);
+
+    expect(result.map(file => file.gistName)).to.deep.equal([
+      "keybindings.json",
+      "snippets|demo.json"
+    ]);
+  });
+
+  it("uploads changed files and cloud settings during normal upload", () => {
+    const result = GistChangeService.GetFilesToUpload(allFiles, gistFiles, false);
+
+    expect(result.map(file => file.gistName)).to.deep.equal([
+      "keybindings.json",
+      "snippets|demo.json",
+      "cloudSettings"
+    ]);
+  });
+
+  it("uploads all files during forced upload", () => {
+    const result = GistChangeService.GetFilesToUpload(allFiles, gistFiles, true);
+
+    expect(result.map(file => file.gistName)).to.deep.equal([
+      "settings.json",
+      "keybindings.json",
+      "snippets|demo.json",
+      "cloudSettings"
+    ]);
+  });
+});


### PR DESCRIPTION
Addresses #508.

## Summary

This changes the upload flow so normal uploads send only files that are new or changed, plus the `cloudSettings` metadata file. Forced uploads keep the previous all-files behavior.

The important safety detail is in `UpdateGIST`: it now separates the files being added/updated from the complete local file set used for deletion decisions. Without that separation, passing only changed files could accidentally mark unchanged remote gist files for deletion.

## Changes

- Added `GistChangeService` to detect changed/new setting files and derive the upload payload.
- Updated upload flow to send the partial payload during normal uploads.
- Preserved full upload behavior when `sync.forceUpload` is enabled.
- Updated summary output to list the actual files uploaded in the run.
- Added regression tests for changed-file detection, normal partial upload, and forced full upload.

## Verification

Ran locally:

```text
npm run compile
npm run tslint-check
npx tsc -p ./
./node_modules/.bin/mocha --recursive "./out/test/service/gistChange/**/*.js"
```

Results:

```text
compile: pass
lint: pass
typecheck: pass
targeted tests: 3 passing
```

I also verified the existing full test suite locally with a VS Code runtime shim, since this older test harness imports `vscode` under Mocha.
